### PR TITLE
Add dark mode persistence per user in database

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -239,4 +239,12 @@ class UsersController extends Controller
             ], 401);
         }
     }
+
+    public function updateDarkMode(Request $request)
+    {
+        $user = auth()->user();
+        $user->dark_mode = $request->dark_mode;
+        $user->save();
+        return response()->json(['dark_mode' => $user->dark_mode], 200);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,7 +25,8 @@ class User extends Authenticatable implements JWTSubject, MustVerifyEmail
         'name',
         'email',
         'password',
-        'image_profile'
+        'image_profile',
+        'dark_mode'
     ];
 
     /**

--- a/database/migrations/2026_05_14_002209_add_dark_mode_to_users_table.php
+++ b/database/migrations/2026_05_14_002209_add_dark_mode_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDarkModeToUsersTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('dark_mode')->default(false)->after('image_profile');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('dark_mode');
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,7 +37,8 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::put('/user/change-details', [UsersController::class, 'updateDetails']);
     Route::put('/user/change-password', [UsersController::class, 'updatePassword']);
     Route::post('/user/change-image-profile', [UsersController::class, 'updateImageProfile']);
-
+    Route::put('/user/dark-mode', [UsersController::class, 'updateDarkMode']);
+    
     //Route for admin
     Route::resource('/admin/users', UserApiController::class);
     Route::resource('/admin/roles', RolesApiController::class);


### PR DESCRIPTION
## Summary
This PR implements server-side persistence for the dark mode preference on a per-user basis. 
Previously, the dark mode toggle was only applied in memory and was lost on every page reload. 
The preference is now stored in the database under the authenticated user's record, ensuring 
it persists across sessions and devices.

## Changes
- `database/migrations/2026_05_14_002209_add_dark_mode_to_users_table.php`: New migration 
  that adds a `dark_mode` boolean column (default: false) to the users table
- `app/Models/User.php`: Added `dark_mode` to the `$fillable` array to allow mass assignment
- `app/Http/Controllers/UsersController.php`: Added `updateDarkMode` method that updates 
  the authenticated user's dark mode preference and returns the updated value
- `routes/api.php`: Registered new protected route `PUT /user/dark-mode` that calls 
  the `updateDarkMode` method, accessible only to authenticated users

## Testing
- Run `kool run artisan migrate` to apply the new migration
- Toggle dark mode while authenticated and reload the page to verify persistence