### PR TITLE
Expose user id and dark_mode field in UserResource

### DIFF
--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -20,13 +20,14 @@ class UserResource extends JsonResource
         $userPermissions = $rolesPermissions->merge($this->permissions->pluck('slug'));
 
         return [
-            //'id' => $this->id,
+            'id'          => $this->id,
             'name'        => $this->name,
             'email'       => $this->email,
             'created_at'  => $this->created_at->format('d-m-Y'),
             'role'        => $roles,
             "permissions" => $userPermissions,
             "image"       => $this->image_profile,
+            "dark_mode"   => $this->dark_mode,
         ];
     }
 }


### PR DESCRIPTION
## Description
Updates the UserResource to expose the user id and dark_mode fields 
in the API response. These fields are required by the frontend to 
identify users and apply their saved dark mode preference on login.

## Changes
- UserResource.php: Uncommented id field that was previously disabled
- UserResource.php: Added dark_mode field to the resource response

## Notes
This change is a dependency of the frontend PR: 
feat: implement persistent dark mode per user session