### PR TITLE
Add field user_id to the table users_subscribe and updated the model …

### DIFF
--- a/app/Http/Controllers/UsersSubscribeController.php
+++ b/app/Http/Controllers/UsersSubscribeController.php
@@ -46,6 +46,7 @@ class UsersSubscribeController extends Controller
 
             $UserSuscribe = new UsersSubscribe();
             $UserSuscribe->email = $request->input('email');
+            $UserSuscribe->user_id = auth()->id();
             $UserSuscribe->save();
 
             DB::commit();

--- a/app/Models/UsersSubscribe.php
+++ b/app/Models/UsersSubscribe.php
@@ -10,5 +10,10 @@ class UsersSubscribe extends Model
     use HasFactory;
 
     protected $table = 'users_subscribe';
-    protected $fillable = ['email'];
+    protected $fillable = ['email', 'user_id'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/database/migrations/2023_09_28_164433_create_users_subscribe_table.php
+++ b/database/migrations/2023_09_28_164433_create_users_subscribe_table.php
@@ -16,6 +16,7 @@ class CreateUsersSubscribeTable extends Migration
         Schema::create('users_subscribe', function (Blueprint $table) {
             $table->id();
             $table->string('email');
+            $table->foreignId('user_id')->nullable()->constrained('users')->onDelete('cascade');
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_09_28_164433_create_users_subscribe_table.php
+++ b/database/migrations/2023_09_28_164433_create_users_subscribe_table.php
@@ -16,7 +16,6 @@ class CreateUsersSubscribeTable extends Migration
         Schema::create('users_subscribe', function (Blueprint $table) {
             $table->id();
             $table->string('email');
-            $table->foreignId('user_id')->nullable()->constrained('users')->onDelete('cascade');
             $table->timestamps();
         });
     }

--- a/database/migrations/2026_05_18_120000_add_user_id_to_users_subscribe_table.php
+++ b/database/migrations/2026_05_18_120000_add_user_id_to_users_subscribe_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUserIdToUsersSubscribeTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::hasColumn('users_subscribe', 'user_id')) {
+            Schema::table('users_subscribe', function (Blueprint $table) {
+                $table->foreignId('user_id')->nullable()->after('email')->constrained('users')->onDelete('cascade');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::hasColumn('users_subscribe', 'user_id')) {
+            Schema::table('users_subscribe', function (Blueprint $table) {
+                $table->dropForeign(['user_id']);
+                $table->dropColumn('user_id');
+            });
+        }
+    }
+}


### PR DESCRIPTION
This pull request updates the user subscription feature to better associate subscriptions with users. The main changes add a `user_id` foreign key to the `users_subscribe` table and update the Eloquent model to reflect this relationship.

**Database schema changes:**

* Added a nullable `user_id` foreign key to the `users_subscribe` table, referencing the `users` table and cascading deletes when a user is removed.

**Model updates:**

* Updated the `UsersSubscribe` model to include `user_id` in the `$fillable` property.
* Added a `user()` relationship method to the `UsersSubscribe` model, defining the inverse relationship to the `User` model.