### PR TITLE
add social media support for artists

### DIFF
--- a/app/Http/Controllers/Artist/ArtistController.php
+++ b/app/Http/Controllers/Artist/ArtistController.php
@@ -83,6 +83,7 @@ class ArtistController extends Controller
                 'price_hour'     => $request->input('price_hour'),
                 'image'          => $linkArtist,
                 'extra_kilometre' => $request->input('extra_kilometre'),
+                'social_media' => $request->input('social_media') ? json_decode($request->input('social_media'), true) : null,
             ]);
 
             $artist->musicalGenders()->sync(json_decode($request->selection));
@@ -239,6 +240,7 @@ class ArtistController extends Controller
             $artist->zone = $request->input('zone');
             $artist->price_hour = $request->input('price_hour');
             $artist->extra_kilometre = $request->input('extra_kilometre');
+            $artist->social_media = $request->input('social_media') ? json_decode($request->input('social_media'), true) : null;
             $linkArtist =  $artist->image;
             $linkManager =  $artist->manager->image;
 

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -18,7 +18,12 @@ class Artist extends Model
         'price_hour',
         'image',
         'extra_kilometre',
-        'points'
+        'points',
+        'social_media'
+    ];
+
+    protected $casts = [
+        'social_media' => 'array',
     ];
 
     public function user()

--- a/database/migrations/2026_05_18_122434_add_social_networks_to_artists_table.php
+++ b/database/migrations/2026_05_18_122434_add_social_networks_to_artists_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSocialNetworksToArtistsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('artists', function (Blueprint $table) {
+            $table->json('social_media')->nullable()->after('points');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('artists', function (Blueprint $table) {
+            $table->dropColumn('social_media');
+        });
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds backend support for social media information in artist profiles.

Artists can now store and update social network links such as Instagram and Facebook through the existing create and update flows.

---

## Changes
- Added `social_media` column to the `artists` table
- Added migration for social media support
- Updated `Artist` model `$fillable` properties
- Added Eloquent cast for `social_media` as array
- Updated `ArtistController` store logic
- Updated `ArtistController` update logic
- Added JSON decoding before persisting social media data

---

## Implementation Details

### Database
A new nullable JSON field was added:
```php
social_media