### PR TITLE
Add cascade drop support to core database migrations

### DIFF
--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 class CreateUsersTable extends Migration
 {
@@ -32,6 +33,6 @@ class CreateUsersTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('users');
+        DB::statement('DROP TABLE IF EXISTS users CASCADE');
     }
 }

--- a/database/migrations/2022_02_02_024642_create_permissions_table.php
+++ b/database/migrations/2022_02_02_024642_create_permissions_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 class CreatePermissionsTable extends Migration
 {
@@ -29,6 +30,6 @@ class CreatePermissionsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('permissions');
+        DB::statement('DROP TABLE IF EXISTS permissions CASCADE');
     }
 }

--- a/database/migrations/2022_02_02_024742_create_roles_table.php
+++ b/database/migrations/2022_02_02_024742_create_roles_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 class CreateRolesTable extends Migration
 {
@@ -29,6 +30,6 @@ class CreateRolesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('roles');
+        DB::statement('DROP TABLE IF EXISTS roles CASCADE');
     }
 }


### PR DESCRIPTION
## Summary
This PR updates the rollback logic of core database migrations to use `CASCADE` when dropping tables.

The change helps prevent migration rollback failures caused by foreign key dependencies between tables.

## Changes
- Added `DB` facade imports to migrations:
  - users
  - permissions
  - roles

- Replaced:
  - `Schema::dropIfExists(...)`

- With:
  - `DB::statement('DROP TABLE IF EXISTS ... CASCADE')`

## Why
Some tables are referenced by foreign keys from other tables, causing rollback operations to fail when attempting to drop them normally.

Using `CASCADE` ensures related constraints and dependent objects are removed automatically during rollback.

## Impact
- Improves database rollback stability
- Prevents migration dependency errors
- Simplifies local development and database resets