### PR TITLE
Add artist rating seeder

### DIFF
--- a/database/seeders/ArtistRatingSeeder.php
+++ b/database/seeders/ArtistRatingSeeder.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\ArtistRating;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ArtistRatingSeeder extends Seeder
+{
+    public function run()
+    {
+        DB::statement('TRUNCATE TABLE artist_ratings RESTART IDENTITY CASCADE;');
+
+        $ratings = [
+            ['user_id' => 17, 'artist_id' => 1,  'rating' => 5],
+            ['user_id' => 17, 'artist_id' => 2,  'rating' => 4],
+            ['user_id' => 17, 'artist_id' => 3,  'rating' => 5],
+            ['user_id' => 17, 'artist_id' => 4,  'rating' => 3],
+            ['user_id' => 17, 'artist_id' => 5,  'rating' => 4],
+            ['user_id' => 17, 'artist_id' => 6,  'rating' => 5],
+            ['user_id' => 17, 'artist_id' => 7,  'rating' => 4],
+            ['user_id' => 17, 'artist_id' => 8,  'rating' => 3],
+            ['user_id' => 17, 'artist_id' => 9,  'rating' => 5],
+            ['user_id' => 17, 'artist_id' => 10, 'rating' => 4],
+            ['user_id' => 17, 'artist_id' => 11, 'rating' => 5],
+            ['user_id' => 17, 'artist_id' => 12, 'rating' => 3],
+            ['user_id' => 17, 'artist_id' => 13, 'rating' => 4],
+            ['user_id' => 17, 'artist_id' => 14, 'rating' => 5],
+            ['user_id' => 17, 'artist_id' => 15, 'rating' => 4],
+
+            ['user_id' => 18, 'artist_id' => 1,  'rating' => 4],
+            ['user_id' => 18, 'artist_id' => 2,  'rating' => 5],
+            ['user_id' => 18, 'artist_id' => 3,  'rating' => 3],
+            ['user_id' => 18, 'artist_id' => 4,  'rating' => 4],
+            ['user_id' => 18, 'artist_id' => 5,  'rating' => 5],
+            ['user_id' => 18, 'artist_id' => 6,  'rating' => 4],
+            ['user_id' => 18, 'artist_id' => 7,  'rating' => 5],
+            ['user_id' => 18, 'artist_id' => 8,  'rating' => 4],
+            ['user_id' => 18, 'artist_id' => 9,  'rating' => 3],
+            ['user_id' => 18, 'artist_id' => 10, 'rating' => 5],
+            ['user_id' => 18, 'artist_id' => 11, 'rating' => 4],
+            ['user_id' => 18, 'artist_id' => 12, 'rating' => 5],
+            ['user_id' => 18, 'artist_id' => 13, 'rating' => 3],
+            ['user_id' => 18, 'artist_id' => 14, 'rating' => 4],
+            ['user_id' => 18, 'artist_id' => 15, 'rating' => 5],
+
+            // Admin califica algunos
+            ['user_id' => 1, 'artist_id' => 1,  'rating' => 5],
+            ['user_id' => 1, 'artist_id' => 3,  'rating' => 4],
+            ['user_id' => 1, 'artist_id' => 6,  'rating' => 5],
+            ['user_id' => 1, 'artist_id' => 10, 'rating' => 3],
+            ['user_id' => 1, 'artist_id' => 13, 'rating' => 4],
+
+            // Artistas califican a otros artistas (no a sí mismos)
+            // user_id 2 es artist_id 1, así que no puede calificar artist_id 1
+            ['user_id' => 2,  'artist_id' => 2,  'rating' => 4],
+            ['user_id' => 2,  'artist_id' => 5,  'rating' => 3],
+            ['user_id' => 2,  'artist_id' => 9,  'rating' => 5],
+
+            ['user_id' => 3,  'artist_id' => 1,  'rating' => 3],
+            ['user_id' => 3,  'artist_id' => 6,  'rating' => 4],
+            ['user_id' => 3,  'artist_id' => 11, 'rating' => 5],
+
+            ['user_id' => 4,  'artist_id' => 1,  'rating' => 4],
+            ['user_id' => 4,  'artist_id' => 7,  'rating' => 5],
+            ['user_id' => 4,  'artist_id' => 12, 'rating' => 3],
+
+            ['user_id' => 5,  'artist_id' => 2,  'rating' => 5],
+            ['user_id' => 5,  'artist_id' => 8,  'rating' => 4],
+            ['user_id' => 5,  'artist_id' => 13, 'rating' => 3],
+
+            ['user_id' => 6,  'artist_id' => 3,  'rating' => 4],
+            ['user_id' => 6,  'artist_id' => 9,  'rating' => 5],
+            ['user_id' => 6,  'artist_id' => 14, 'rating' => 4],
+
+            ['user_id' => 7,  'artist_id' => 4,  'rating' => 3],
+            ['user_id' => 7,  'artist_id' => 10, 'rating' => 5],
+            ['user_id' => 7,  'artist_id' => 15, 'rating' => 4],
+
+            ['user_id' => 8,  'artist_id' => 1,  'rating' => 5],
+            ['user_id' => 8,  'artist_id' => 5,  'rating' => 4],
+            ['user_id' => 8,  'artist_id' => 11, 'rating' => 3],
+
+            ['user_id' => 9,  'artist_id' => 2,  'rating' => 4],
+            ['user_id' => 9,  'artist_id' => 6,  'rating' => 5],
+            ['user_id' => 9,  'artist_id' => 12, 'rating' => 4],
+
+            ['user_id' => 10, 'artist_id' => 3,  'rating' => 3],
+            ['user_id' => 10, 'artist_id' => 7,  'rating' => 5],
+            ['user_id' => 10, 'artist_id' => 13, 'rating' => 4],
+        ];
+
+        foreach ($ratings as $rating) {
+            ArtistRating::create($rating);
+        }
+    }
+}

--- a/database/seeders/ArtistRatingSeeder.php
+++ b/database/seeders/ArtistRatingSeeder.php
@@ -52,8 +52,6 @@ class ArtistRatingSeeder extends Seeder
             ['user_id' => 1, 'artist_id' => 10, 'rating' => 3],
             ['user_id' => 1, 'artist_id' => 13, 'rating' => 4],
 
-            // Artistas califican a otros artistas (no a sí mismos)
-            // user_id 2 es artist_id 1, así que no puede calificar artist_id 1
             ['user_id' => 2,  'artist_id' => 2,  'rating' => 4],
             ['user_id' => 2,  'artist_id' => 5,  'rating' => 3],
             ['user_id' => 2,  'artist_id' => 9,  'rating' => 5],

--- a/database/seeders/ArtistRatingSeeder.php
+++ b/database/seeders/ArtistRatingSeeder.php
@@ -45,7 +45,6 @@ class ArtistRatingSeeder extends Seeder
             ['user_id' => 18, 'artist_id' => 14, 'rating' => 4],
             ['user_id' => 18, 'artist_id' => 15, 'rating' => 5],
 
-            // Admin califica algunos
             ['user_id' => 1, 'artist_id' => 1,  'rating' => 5],
             ['user_id' => 1, 'artist_id' => 3,  'rating' => 4],
             ['user_id' => 1, 'artist_id' => 6,  'rating' => 5],

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -34,5 +34,6 @@ class DatabaseSeeder extends Seeder
         $this->call(MusicalGendersSeeder::class);
         $this->call(ArtistSeeder::class);
         $this->call(ShoppingCardDetailsSeeder::class);
+        $this->call(ArtistRatingSeeder::class);
     }
 }


### PR DESCRIPTION
## Summary
This PR adds a new seeder for artist ratings and registers it in the main database seeder.

## Changes
- Added `ArtistRatingSeeder`
- Registered the seeder inside `DatabaseSeeder`
- Included artist rating sample data in the seeding process

## Why
This helps provide test/demo rating data for artists during local development and testing.
