### PR TITLE
streamline artist rating update and deletion logic

### DIFF
--- a/app/Http/Controllers/ArtistRatingController.php
+++ b/app/Http/Controllers/ArtistRatingController.php
@@ -11,20 +11,20 @@ class ArtistRatingController extends Controller
     public function rateArtist(Request $request, $id)
     {
         $request->validate([
-            'rating' => 'required|integer|min:1|max:5'
+            'rating' => 'required|integer|min:0|max:5'
         ]);
 
         $artist = Artist::findOrFail($id);
 
-        ArtistRating::updateOrCreate(
-            [
-                'user_id' => auth()->id(),
-                'artist_id' => $artist->id
-            ],
-            [
-                'rating' => $request->rating
-            ]
-        );
+        match ((int)$request->rating) {
+            0 => ArtistRating::where('user_id', auth()->id())->where('artist_id', $artist->id)->delete(),
+            default => ArtistRating::updateOrCreate(
+                ['user_id' => auth()->id(), 'artist_id' => $artist->id],
+                ['rating' => $request->rating]
+            ),
+        };
+
+        $message = ($request->rating == 0) ? 'Calificación eliminada' : '¡Calificación guardada con éxito!';
 
         $newAverage = ArtistRating::where('artist_id', $artist->id)->avg('rating');
 


### PR DESCRIPTION
## Summary of Changes

### Artist Rating Controller Updates
- Updated the `rating` validation rules to allow values from `0` to `5` instead of only `1` to `5`.
- Added support for removing an artist rating when the received rating value is `0`.
- Replaced the previous `updateOrCreate` logic with a `match` expression:
  - `0` → Deletes the existing user rating for the artist.
  - Default → Creates or updates the artist rating as before.
- Added a dynamic success message:
  - `"Calificación eliminada"` when the rating is removed.
  - `"¡Calificación guardada con éxito!"` when the rating is saved or updated.
- Kept the average artist rating recalculation after rating changes.