### PR TITLE
update newsletter logic to include guests, handle Mailtrap limits, an…

### DIFF
--- a/app/Http/Controllers/UsersSubscribeController.php
+++ b/app/Http/Controllers/UsersSubscribeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\UsersSubscribe;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Mail;
@@ -72,31 +73,55 @@ class UsersSubscribeController extends Controller
      */
     public function sendEmailToSubscribers(Request $request)
     {
+            $validated = $request->validate([
+            'subject' => ['required', 'string', 'max:255'],
+            'content' => ['required', 'string'],
+            'role_ids' => ['required', 'array', 'min:1'],
+            'role_ids.*' => [
+                'integer',
+                function ($attribute, $value, $fail) {
+                    if ($value !== 0 && !DB::table('roles')->where('id', $value)->exists()) {
+                        $fail('Uno de los roles seleccionados no existe.');
+                    }
+                },
+            ],
+        ]);
+
         try {
             Gate::authorize('send-newsletters');
 
-            $validated = $request->validate([
-                'subject' => ['required', 'string', 'max:255'],
-                'content' => ['required', 'string'],
-                'role_ids' => ['required', 'array', 'min:1'],
-                'role_ids.*' => ['integer', 'exists:roles,id'],
-            ]);
-
             $roleIds = collect($validated['role_ids'])->unique()->values()->all();
+            
+            $listaFinalCorreos = [];
 
-            $emailSubscribers = UsersSubscribe::whereHas('user.roles', function ($query) use ($roleIds) {
-                $query->whereIn('roles.id', $roleIds);
-            })
-            ->pluck('email')
-            ->filter()
-            ->unique()
-            ->values()
-            ->all();
+            $rolesReales = array_filter($roleIds, function($id) {
+                return $id !== 0;
+            });
+
+            if (!empty($rolesReales)) {
+                $correosPorRol = User::whereHas('roles', function ($query) use ($rolesReales) {
+                    $query->whereIn('roles.id', $rolesReales);
+                })
+                ->pluck('email')
+                ->toArray();
+                
+                $listaFinalCorreos = array_merge($listaFinalCorreos, $correosPorRol);
+            }
+
+            if (in_array(0, $roleIds)) {
+                $correosInvitados = UsersSubscribe::whereNull('user_id')
+                ->pluck('email')
+                ->toArray();
+
+                $listaFinalCorreos = array_merge($listaFinalCorreos, $correosInvitados);
+            }
+
+            $emailSubscribers = collect($listaFinalCorreos)->filter()->unique()->values()->all();
 
             if (empty($emailSubscribers)) {
                 return response()->json([
                     'success' => false,
-                    'message' => 'No hay destinatarios disponibles con los roles seleccionados.',
+                    'message' => 'No hay destinatarios disponibles con las opciones seleccionadas.',
                     'errors' => [
                         'role_ids' => ['No hay destinatarios disponibles con esos roles.'],
                     ],
@@ -107,7 +132,12 @@ class UsersSubscribeController extends Controller
             $content = $validated['content'];
 
             foreach ($emailSubscribers as $email) {
-                Mail::to($email)->queue(new SendNewsletter($subject, $content));
+                try {
+                    Mail::to($email)->queue(new SendNewsletter($subject, $content));
+                    sleep(3); 
+                } catch (\Throwable $th) {
+                    continue;
+                }
             }
 
             return response()->json([

--- a/app/Http/Controllers/UsersSubscribeController.php
+++ b/app/Http/Controllers/UsersSubscribeController.php
@@ -92,31 +92,31 @@ class UsersSubscribeController extends Controller
 
             $roleIds = collect($validated['role_ids'])->unique()->values()->all();
             
-            $listaFinalCorreos = [];
+            $finalEmailList = [];
 
-            $rolesReales = array_filter($roleIds, function($id) {
+            $validRoleIds = array_filter($roleIds, function($id) {
                 return $id !== 0;
             });
 
-            if (!empty($rolesReales)) {
-                $correosPorRol = User::whereHas('roles', function ($query) use ($rolesReales) {
-                    $query->whereIn('roles.id', $rolesReales);
+            if (!empty($validRoleIds)) {
+                $emailsByRole = User::whereHas('roles', function ($query) use ($validRoleIds) {
+                    $query->whereIn('roles.id', $validRoleIds);
                 })
                 ->pluck('email')
                 ->toArray();
                 
-                $listaFinalCorreos = array_merge($listaFinalCorreos, $correosPorRol);
+                $finalEmailList = array_merge($finalEmailList, $emailsByRole);
             }
 
             if (in_array(0, $roleIds)) {
-                $correosInvitados = UsersSubscribe::whereNull('user_id')
+                $guestEmails = UsersSubscribe::whereNull('user_id')
                 ->pluck('email')
                 ->toArray();
 
-                $listaFinalCorreos = array_merge($listaFinalCorreos, $correosInvitados);
+                $finalEmailList = array_merge($finalEmailList, $guestEmails);
             }
 
-            $emailSubscribers = collect($listaFinalCorreos)->filter()->unique()->values()->all();
+            $emailSubscribers = collect($finalEmailList)->filter()->unique()->values()->all();
 
             if (empty($emailSubscribers)) {
                 return response()->json([

--- a/resources/views/mails/newsletter.blade.php
+++ b/resources/views/mails/newsletter.blade.php
@@ -16,8 +16,8 @@
                     <table class="newsletter-card" role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
                         <tr>
                             <td class="newsletter-hero">
-                                <img src="{{ $message->embed(public_path('logovibeer.png')) }}" alt="Música GSM" class="newsletter-logo">
-                                <p class="newsletter-kicker">Música GSM</p>
+                                <img src="{{ $message->embed(public_path('logovibeer.png')) }}" alt="Vibeer" class="newsletter-logo">
+                                <p class="newsletter-kicker">Vibeer</p>
                                 <h1 class="newsletter-title">{{ $subject }}</h1>
                                 <p class="newsletter-subtitle">Novedades, avisos y contenido especial para tu comunidad.</p>
                             </td>
@@ -31,7 +31,7 @@
                         </tr>
                         <tr>
                             <td class="newsletter-footer">
-                                <p>Recibiste este correo porque formas parte de la comunidad de Música GSM.</p>
+                                <p>Recibiste este correo porque formas parte de la comunidad de Vibeer.</p>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
# Newsletter Recipient and Branding Updates

## Backend Improvements
- Added support for sending newsletters to both registered users and guest subscribers.
- Imported the `User` model to retrieve emails directly from users by role.
- Updated validation logic to allow a special role value (`0`) for guest subscribers.
- Added custom validation to verify that selected roles exist in the database.
- Refactored recipient collection logic:
  - Registered users are filtered by selected roles.
  - Guest subscribers are included when the guest option is selected.
- Merged and cleaned recipient lists to avoid duplicate or empty emails.
- Updated error messages to use more generic “selected options” wording.
- Added `try/catch` protection around queued email sending to prevent the process from stopping on individual failures.
- Added a small delay between email queue operations.

## Email Template Updates
- Replaced all “Música GSM” branding references with “Vibeer”.
- Updated newsletter logo alt text to match the new branding.
- Updated footer text to reflect the Vibeer community.