### PR TITLE
configure Mailhog in docker and .env, remove sleep in newsletter loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,13 +31,13 @@ REDIS_PASSWORD=null
 REDIS_PORT=6379
 
 MAIL_MAILER=smtp
-MAIL_HOST=smtp.mailtrap.io
-MAIL_PORT=2525
-MAIL_USERNAME=your_mailtrap_username
-MAIL_PASSWORD=your_mailtrap_password
-MAIL_ENCRYPTION=tls
-MAIL_FROM_NAME="Nombre del remitente"
-MAIL_FROM_ADDRESS="example@email.com"
+MAIL_HOST=mailhog
+MAIL_PORT=1025
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=null
+MAIL_FROM_ADDRESS="tu_correo@gmail.com"
+MAIL_FROM_NAME="Vibeer"
 
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/app/Http/Controllers/UsersSubscribeController.php
+++ b/app/Http/Controllers/UsersSubscribeController.php
@@ -135,7 +135,7 @@ class UsersSubscribeController extends Controller
                 try {
                     Mail::to($email)->queue(new SendNewsletter($subject, $content));
                 } catch (\Throwable $th) {
-                    continue; 
+                    continue;
                 }
             }
 

--- a/app/Http/Controllers/UsersSubscribeController.php
+++ b/app/Http/Controllers/UsersSubscribeController.php
@@ -134,9 +134,8 @@ class UsersSubscribeController extends Controller
             foreach ($emailSubscribers as $email) {
                 try {
                     Mail::to($email)->queue(new SendNewsletter($subject, $content));
-                    sleep(3); 
                 } catch (\Throwable $th) {
-                    continue;
+                    continue; 
                 }
             }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,14 @@ services:
     networks:
         - network-music
 
+  mailhog:
+      image: 'mailhog/mailhog:latest'
+      ports:
+        - '1025:1025'
+        - '8025:8025'
+      networks:
+        - network-music
+
 networks:
   network-music:
     driver: bridge


### PR DESCRIPTION
# Summary of Changes

## Email Configuration Updates

* Updated the default mail configuration in `.env.example` to use **MailHog** instead of Mailtrap for local email testing.
* Changed SMTP host from `smtp.mailtrap.io` to `mailhog`.
* Updated mail port from `2525` to `1025`.
* Removed default Mailtrap credentials and encryption settings.
* Updated the default sender information:

  * `MAIL_FROM_NAME` is now set to `"Vibeer"`.
  * `MAIL_FROM_ADDRESS` now uses a placeholder Gmail address.

## Newsletter Sending Optimization

* Removed the `sleep(3)` delay between newsletter email queue dispatches in `UsersSubscribeController`.
* This improves newsletter processing performance by allowing emails to be queued without unnecessary waiting time.
* Maintained exception handling to continue processing remaining subscribers even if an error occurs for a specific email.

## Docker Environment Improvements

* Added a new `mailhog` service to `docker-compose.yml`.
* Exposed:

  * SMTP server on port `1025`
  * MailHog web interface on port `8025`
* Connected the MailHog service to the existing `network-music` Docker network for seamless local email testing.
