### PR TITLE
add 3 new clients and favourite artists seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -36,5 +36,6 @@ class DatabaseSeeder extends Seeder
         $this->call(ShoppingCardDetailsSeeder::class);
         $this->call(ArtistRatingSeeder::class);
         $this->call(ArtistSalesSeeder::class);
+        $this->call(FavouriteArtistsSeeder::class);
     }
 }

--- a/database/seeders/FavouriteArtistsSeeder.php
+++ b/database/seeders/FavouriteArtistsSeeder.php
@@ -27,14 +27,16 @@ class FavouriteArtistsSeeder extends Seeder
             ['user_id' => 18, 'artist_id' => 6],
             ['user_id' => 18, 'artist_id' => 10],
 
-            ['user_id' => 1, 'artist_id' => 3],
-            ['user_id' => 1, 'artist_id' => 7],
+            ['user_id' => 19, 'artist_id' => 3],
+            ['user_id' => 19, 'artist_id' => 7],
 
-            ['user_id' => 2, 'artist_id' => 4],
-            ['user_id' => 2, 'artist_id' => 8],
-            ['user_id' => 2, 'artist_id' => 11],
-            ['user_id' => 2, 'artist_id' => 13],
-            ['user_id' => 2, 'artist_id' => 14],
+            ['user_id' => 20, 'artist_id' => 4],
+            ['user_id' => 20, 'artist_id' => 8],
+            ['user_id' => 20, 'artist_id' => 11],
+            ['user_id' => 20, 'artist_id' => 13],
+            ['user_id' => 20, 'artist_id' => 14],
+
+            ['user_id' => 21, 'artist_id' => 4],
 
         ];
 

--- a/database/seeders/FavouriteArtistsSeeder.php
+++ b/database/seeders/FavouriteArtistsSeeder.php
@@ -2,51 +2,30 @@
 
 namespace Database\Seeders;
 
+use App\Models\FavouriteArtists;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
 class FavouriteArtistsSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
     public function run()
     {
         DB::statement('TRUNCATE TABLE favourite_artists RESTART IDENTITY CASCADE;');
 
-        $favourites = [
-            ['user_id' => 17, 'artist_id' => 1],
-            ['user_id' => 17, 'artist_id' => 5],
-            ['user_id' => 17, 'artist_id' => 9],
-            ['user_id' => 17, 'artist_id' => 12],
-            ['user_id' => 17, 'artist_id' => 15],
+        $customerIds = [17, 18, 19, 20, 21];
+        $artistIds   = range(1, 15);
+        $cantidades  = [2, 3, 5];
 
-            ['user_id' => 18, 'artist_id' => 2],
-            ['user_id' => 18, 'artist_id' => 6],
-            ['user_id' => 18, 'artist_id' => 10],
+        foreach ($customerIds as $index => $customerId) {
+            $limite = $cantidades[$index % count($cantidades)];
+            $vueltas = range(1, $limite);
 
-            ['user_id' => 19, 'artist_id' => 3],
-            ['user_id' => 19, 'artist_id' => 7],
-
-            ['user_id' => 20, 'artist_id' => 4],
-            ['user_id' => 20, 'artist_id' => 8],
-            ['user_id' => 20, 'artist_id' => 11],
-            ['user_id' => 20, 'artist_id' => 13],
-            ['user_id' => 20, 'artist_id' => 14],
-
-            ['user_id' => 21, 'artist_id' => 4],
-
-        ];
-
-        foreach ($favourites as $favourite) {
-            DB::table('favourite_artists')->insert([
-                'user_id'    => $favourite['user_id'],
-                'artist_id'  => $favourite['artist_id'],
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]);
+            foreach ($vueltas as $i => $vuelta) {
+                FavouriteArtists::create([
+                    'user_id'   => $customerId,
+                    'artist_id' => $artistIds[($index + $i) % count($artistIds)],
+                ]);
+            }
         }
     }
 }

--- a/database/seeders/FavouriteArtistsSeeder.php
+++ b/database/seeders/FavouriteArtistsSeeder.php
@@ -14,13 +14,13 @@ class FavouriteArtistsSeeder extends Seeder
 
         $customerIds = [17, 18, 19, 20, 21];
         $artistIds   = range(1, 15);
-        $cantidades  = [2, 3, 5];
+        $quantities  = [2, 3, 5];
 
         foreach ($customerIds as $index => $customerId) {
-            $limite = $cantidades[$index % count($cantidades)];
-            $vueltas = range(1, $limite);
+            $limit = $quantities[$index % count($quantities)];
+            $iterations = range(1, $limit);
 
-            foreach ($vueltas as $i => $vuelta) {
+            foreach ($iterations as $i => $iteration) {
                 FavouriteArtists::create([
                     'user_id'   => $customerId,
                     'artist_id' => $artistIds[($index + $i) % count($artistIds)],

--- a/database/seeders/FavouriteArtistsSeeder.php
+++ b/database/seeders/FavouriteArtistsSeeder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class FavouriteArtistsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::statement('TRUNCATE TABLE favourite_artists RESTART IDENTITY CASCADE;');
+
+        $favourites = [
+            ['user_id' => 17, 'artist_id' => 1],
+            ['user_id' => 17, 'artist_id' => 5],
+            ['user_id' => 17, 'artist_id' => 9],
+            ['user_id' => 17, 'artist_id' => 12],
+            ['user_id' => 17, 'artist_id' => 15],
+
+            ['user_id' => 18, 'artist_id' => 2],
+            ['user_id' => 18, 'artist_id' => 6],
+            ['user_id' => 18, 'artist_id' => 10],
+
+            ['user_id' => 1, 'artist_id' => 3],
+            ['user_id' => 1, 'artist_id' => 7],
+
+            ['user_id' => 2, 'artist_id' => 4],
+            ['user_id' => 2, 'artist_id' => 8],
+            ['user_id' => 2, 'artist_id' => 11],
+            ['user_id' => 2, 'artist_id' => 13],
+            ['user_id' => 2, 'artist_id' => 14],
+
+        ];
+
+        foreach ($favourites as $favourite) {
+            DB::table('favourite_artists')->insert([
+                'user_id'    => $favourite['user_id'],
+                'artist_id'  => $favourite['artist_id'],
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -142,5 +142,26 @@ class UserSeeder extends Seeder
             'password' => bcrypt('password'),
             'image_profile' => 'https://secure.gravatar.com/avatar/' . md5(strtolower(trim('fernando@gmail.com'))) . '?s=800&d=retro',
         ])->roles()->sync(3);
+
+        User::create([
+            'name' => 'Carlos Ramirez Lopez',
+            'email' => 'carlosramirez@gmail.com',
+            'password' => bcrypt('password'),
+            'image_profile' => 'https://secure.gravatar.com/avatar/' . md5(strtolower(trim('carlosramirez@gmail.com'))) . '?s=800&d=retro',
+        ])->roles()->sync(3);
+
+        User::create([
+            'name' => 'Valeria Torres Silva',
+            'email' => 'valeriatorres@gmail.com',
+            'password' => bcrypt('password'),
+            'image_profile' => 'https://secure.gravatar.com/avatar/' . md5(strtolower(trim('valeriatorres@gmail.com'))) . '?s=800&d=retro',
+        ])->roles()->sync(3);
+
+        User::create([
+            'name' => 'Diego Hernandez Ruiz',
+            'email' => 'diegohernandez@gmail.com',
+            'password' => bcrypt('password'),
+            'image_profile' => 'https://secure.gravatar.com/avatar/' . md5(strtolower(trim('diegohernandez@gmail.com'))) . '?s=800&d=retro',
+        ])->roles()->sync(3);
     }
 }


### PR DESCRIPTION
# Summary of Changes

## New Favourite Artists Seeder

* Created a new `FavouriteArtistsSeeder` to populate the `favourite_artists` table with sample user-artist relationships.
* Added logic to truncate the table and reset its identity sequence before inserting seed data, ensuring a clean and consistent dataset on every seed execution.
* Seeded multiple favorite artist associations across different users to simulate real user preferences and engagement.

## Database Seeder Registration

* Updated `DatabaseSeeder` to include the execution of `FavouriteArtistsSeeder`.
* Ensures favorite artist data is automatically generated whenever the database seed process is run.

## Additional Seeded Users

* Added three new test users to `UserSeeder`:

  * Carlos Ramirez Lopez
  * Valeria Torres Silva
  * Diego Hernandez Ruiz

## User Configuration

* Configured each new user with:

  * Name
  * Email address
  * Encrypted password using `bcrypt`
  * Gravatar-based profile image generated from their email address

## Role Assignment

* Assigned role ID `3` to all newly created users using the existing role synchronization mechanism.
* Ensures the new accounts have the correct permissions immediately after seeding.