### PR TITLE
feat: Add DashboardStats controller and route to get stats of admin d…

### DIFF
--- a/app/Http/Controllers/Admin/DashboardStatsController.php
+++ b/app/Http/Controllers/Admin/DashboardStatsController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\Artist;
+use App\Models\ArtistSale;
 use App\Models\MusicalGender;
-use App\Models\Quotations;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -18,24 +18,19 @@ class DashboardStatsController extends Controller
             $periodDays = (int) $request->input('period_days', 30);
             $periodDays = $periodDays > 0 ? $periodDays : 30;
             $periodStart = Carbon::now()->subDays($periodDays);
+            $clients = User::whereHas('roles', function ($query) {
+                $query->where('roles.id', 3);
+            });
 
             $cards = [
                 $this->makeCard(
                     'users',
-                    'Usuarios registrados',
-                    User::count(),
+                    'Clientes registrados',
+                    (clone $clients)->count(),
                     [
                         [
-                            'label' => 'Verificados',
-                            'value' => User::whereNotNull('email_verified_at')->count(),
-                        ],
-                        [
-                            'label' => 'Sin verificar',
-                            'value' => User::whereNull('email_verified_at')->count(),
-                        ],
-                        [
                             'label' => 'Nuevos últimos ' . $periodDays . ' días',
-                            'value' => User::where('created_at', '>=', $periodStart)->count(),
+                            'value' => (clone $clients)->where('created_at', '>=', $periodStart)->count(),
                         ],
                     ]
                 ),
@@ -78,17 +73,21 @@ class DashboardStatsController extends Controller
                     ]
                 ),
                 $this->makeCard(
-                    'quotations',
-                    'Cotizaciones',
-                    Quotations::count(),
+                    'sales',
+                    'Ventas',
+                    ArtistSale::count(),
                     [
                         [
-                            'label' => 'Últimos ' . $periodDays . ' días',
-                            'value' => Quotations::where('created_at', '>=', $periodStart)->count(),
+                            'label' => 'Monto acumulado',
+                            'value' => (float) ArtistSale::sum('amount'),
                         ],
                         [
-                            'label' => 'Este mes',
-                            'value' => Quotations::whereBetween('created_at', [Carbon::now()->startOfMonth(), Carbon::now()->endOfMonth()])->count(),
+                            'label' => 'Monto últimos ' . $periodDays . ' días',
+                            'value' => (float) ArtistSale::where('created_at', '>=', $periodStart)->sum('amount'),
+                        ],
+                        [
+                            'label' => 'Ticket promedio últimos ' . $periodDays . ' días',
+                            'value' => round((float) ArtistSale::where('created_at', '>=', $periodStart)->avg('amount'), 2),
                         ],
                     ]
                 ),

--- a/app/Http/Controllers/Admin/DashboardStatsController.php
+++ b/app/Http/Controllers/Admin/DashboardStatsController.php
@@ -19,7 +19,7 @@ class DashboardStatsController extends Controller
             $periodDays = $periodDays > 0 ? $periodDays : 30;
             $periodStart = Carbon::now()->subDays($periodDays);
             $clients = User::whereHas('roles', function ($query) {
-                $query->where('roles.id', 3);
+                $query->where('roles.slug', User::ROLE_CLIENT);
             });
 
             $cards = [

--- a/app/Http/Controllers/Admin/DashboardStatsController.php
+++ b/app/Http/Controllers/Admin/DashboardStatsController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Artist;
+use App\Models\MusicalGender;
+use App\Models\Quotations;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+class DashboardStatsController extends Controller
+{
+    public function index(Request $request)
+    {
+        try {
+            $periodDays = (int) $request->input('period_days', 30);
+            $periodDays = $periodDays > 0 ? $periodDays : 30;
+            $periodStart = Carbon::now()->subDays($periodDays);
+
+            $cards = [
+                $this->makeCard(
+                    'users',
+                    'Usuarios registrados',
+                    User::count(),
+                    [
+                        [
+                            'label' => 'Verificados',
+                            'value' => User::whereNotNull('email_verified_at')->count(),
+                        ],
+                        [
+                            'label' => 'Sin verificar',
+                            'value' => User::whereNull('email_verified_at')->count(),
+                        ],
+                        [
+                            'label' => 'Nuevos últimos ' . $periodDays . ' días',
+                            'value' => User::where('created_at', '>=', $periodStart)->count(),
+                        ],
+                    ]
+                ),
+                $this->makeCard(
+                    'musical_genders',
+                    'Géneros musicales',
+                    MusicalGender::count(),
+                    [
+                        [
+                            'label' => 'Con artistas asociados',
+                            'value' => MusicalGender::whereHas('artists')->count(),
+                        ],
+                        [
+                            'label' => 'Sin artistas asociados',
+                            'value' => MusicalGender::whereDoesntHave('artists')->count(),
+                        ],
+                        [
+                            'label' => 'Creados últimos ' . $periodDays . ' días',
+                            'value' => MusicalGender::where('created_at', '>=', $periodStart)->count(),
+                        ],
+                    ]
+                ),
+                $this->makeCard(
+                    'artists',
+                    'Artistas registrados',
+                    Artist::count(),
+                    [
+                        [
+                            'label' => 'Con manager',
+                            'value' => Artist::has('manager')->count(),
+                        ],
+                        [
+                            'label' => 'Sin manager',
+                            'value' => Artist::doesntHave('manager')->count(),
+                        ],
+                        [
+                            'label' => 'Nuevos últimos ' . $periodDays . ' días',
+                            'value' => Artist::where('created_at', '>=', $periodStart)->count(),
+                        ],
+                    ]
+                ),
+                $this->makeCard(
+                    'quotations',
+                    'Cotizaciones',
+                    Quotations::count(),
+                    [
+                        [
+                            'label' => 'Últimos ' . $periodDays . ' días',
+                            'value' => Quotations::where('created_at', '>=', $periodStart)->count(),
+                        ],
+                        [
+                            'label' => 'Este mes',
+                            'value' => Quotations::whereBetween('created_at', [Carbon::now()->startOfMonth(), Carbon::now()->endOfMonth()])->count(),
+                        ],
+                    ]
+                ),
+            ];
+
+            return response()->json([
+                'success' => true,
+                'data' => [
+                    'period_days' => $periodDays,
+                    'generated_at' => Carbon::now()->toIso8601String(),
+                    'cards' => $cards,
+                ],
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    private function makeCard(string $key, string $label, int $total, array $breakdown): array
+    {
+        return [
+            'key' => $key,
+            'label' => $label,
+            'total' => $total,
+            'breakdown' => $breakdown,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\Auth\ForgotPasswordController;
 use App\Http\Controllers\PaymentController;
 use App\Http\Controllers\Artist\ArtistSalesController;
 use App\Http\Controllers\ArtistRatingController;
+use App\Http\Controllers\Admin\DashboardStatsController;
 
 // Routes for login without sesion
 Route::post('/login', [AuthController::class, 'login']);
@@ -50,6 +51,7 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::resource('/admin/roles', RolesApiController::class);
     Route::resource('/admin/permissions', PermissionsApiController::class);
     Route::resource('/admin/musical-genders', MusicalsGendersController::class);
+    Route::get('/admin/dashboard-overview', [DashboardStatsController::class, 'index']);
 
     //Route for artist
     Route::post('/artist-new/up-date/{id}', [ArtistController::class, 'updateDetails']);


### PR DESCRIPTION
This pull request introduces a new API endpoint for the admin dashboard to provide statistical overviews of users, musical genres, artists, and quotations. The main addition is a controller that aggregates and returns these statistics, along with the necessary route registration.

**New Admin Dashboard Statistics API**

*Feature Implementation:*
- Added a new controller, `DashboardStatsController`, which calculates and returns key statistics for the admin dashboard, including counts and breakdowns for users, musical genres, artists, and quotations over configurable time periods.

*Routing:*
- Registered the new API route `/admin/dashboard-overview` (GET) to serve the dashboard statistics via the `DashboardStatsController@index` method. [[1]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR26) [[2]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR54)…ashboard