### PR TITLE
remove web login redirect to enforce native API 401 JSON responses

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -14,8 +14,5 @@ class Authenticate extends Middleware
      */
     protected function redirectTo($request)
     {
-        if (! $request->expectsJson()) {
-            return route('login');
-        }
     }
 }


### PR DESCRIPTION
## 📝 Description
Refactored the core authentication middleware to support a pure headless API architecture. Removed the legacy web-based route redirect fallback mechanism, ensuring that unauthenticated API clients natively receive standard `401 Unauthorized` header responses instead of trying to hit an unmapped web login template.

---

## 🛠️ Changes Made

### 🔒 Core Security Middleware (`app/Http/Middleware/Authenticate.php`)
* Cleaned out the conditional block inside `redirectTo()`.
* Prevented automated web route evaluation sequences for standard endpoint calls, aligning the platform's backend validation failures with the newly updated frontend Axios interceptor requirements.

---

##  Type of Change
- [x] Refactor (clean up legacy web scaffolding for headless API compatibility)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)