### PR TITLE
feat: Implement ClientDashboard controller to fetch client statistics

### DIFF
--- a/app/Http/Controllers/Client/ClientDashboardController.php
+++ b/app/Http/Controllers/Client/ClientDashboardController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Http\Controllers\Client;
+
+use App\Http\Controllers\Controller;
+use App\Models\ShoppingCard;
+use App\Models\ShoppingCardDetail;
+use App\Models\ArtistSale;
+use App\Models\FavouriteArtists;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Carbon\Carbon;
+
+class ClientDashboardController extends Controller
+{
+    public function index(Request $request)
+    {
+        try {
+            $periodDays = (int) $request->input('period_days', 30);
+            $periodDays = $periodDays > 0 ? $periodDays : 30;
+            $periodStart = Carbon::now()->subDays($periodDays);
+
+            $userId = Auth::id();
+
+            $cart = ShoppingCard::with(['shoppingCardDetail.artist'])
+                ->where('user_id', $userId)
+                ->where('status', 1)
+                ->first();
+
+            $cartItems = [];
+            $cartTotalItems = 0;
+            $cartTotalAmount = 0.0;
+
+            if ($cart) {
+                foreach ($cart->shoppingCardDetail as $detail) {
+                    $subtotal = (float) $detail->hours * (float) $detail->price;
+                    $cartItems[] = [
+                        'id' => $detail->id,
+                        'artist_id' => $detail->artist_id,
+                        'artist_name' => $detail->artist ? ($detail->artist->name ?? null) : null,
+                        'hours' => $detail->hours,
+                        'price' => (float) $detail->price,
+                        'subtotal' => $subtotal,
+                    ];
+                    $cartTotalItems += 1;
+                    $cartTotalAmount += $subtotal;
+                }
+            }
+
+            $purchasesQuery = ArtistSale::where('customer_id', $userId)->orderBy('created_at', 'desc');
+            $purchases = $purchasesQuery->get();
+            $totalPurchases = $purchases->count();
+            $totalSpent = (float) $purchases->sum('amount');
+            $lastPurchase = null;
+            if ($purchases->isNotEmpty()) {
+                $lp = $purchases->first();
+                $lastPurchase = [
+                    'id' => $lp->id,
+                    'artist_id' => $lp->artist_id,
+                    'artist_name' => $lp->artist ? ($lp->artist->name ?? null) : null,
+                    'amount' => (float) $lp->amount,
+                    'date' => $lp->created_at ? $lp->created_at->toIso8601String() : null,
+                ];
+            }
+
+            $favsQuery = FavouriteArtists::with('artist')->where('user_id', $userId);
+            $favs = $favsQuery->get();
+            $totalFavs = $favs->count();
+            $addedLastPeriod = $favsQuery->where('created_at', '>=', $periodStart)->count();
+            $examples = $favs->take(5)->map(function ($f) {
+                return [
+                    'artist_id' => $f->artist_id,
+                    'artist_name' => $f->artist ? ($f->artist->name ?? null) : null,
+                    'added_at' => $f->created_at ? $f->created_at->toIso8601String() : null,
+                ];
+            })->values();
+
+            $payload = [
+                'success' => true,
+                'data' => [
+                    'period_days' => $periodDays,
+                    'generated_at' => Carbon::now()->toIso8601String(),
+                    'cards' => [
+                        [
+                            'key' => 'cart',
+                            'label' => 'Carrito activo',
+                            'total' => $cartTotalItems,
+                            'breakdown' => [
+                                'total_items' => $cartTotalItems,
+                                'total_amount' => round($cartTotalAmount, 2),
+                                'status' => $cart ? $cart->status : null,
+                            ],
+                            'items' => $cartItems,
+                        ],
+                        [
+                            'key' => 'purchases',
+                            'label' => 'Compras realizadas',
+                            'total' => $totalPurchases,
+                            'breakdown' => [
+                                'total_purchases' => $totalPurchases,
+                                'total_spent' => round($totalSpent, 2),
+                                'last_purchase' => $lastPurchase,
+                            ],
+                        ],
+                        [
+                            'key' => 'favourites',
+                            'label' => 'Artistas favoritos',
+                            'total' => $totalFavs,
+                            'breakdown' => [
+                                'added_last_' . $periodDays . '_days' => $addedLastPeriod,
+                            ],
+                            'examples' => $examples,
+                        ],
+                    ],
+                ],
+            ];
+
+            return response()->json($payload, 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/Client/ClientDashboardController.php
+++ b/app/Http/Controllers/Client/ClientDashboardController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Client;
 
 use App\Http\Controllers\Controller;
 use App\Models\ShoppingCard;
-use App\Models\ShoppingCardDetail;
 use App\Models\ArtistSale;
 use App\Models\FavouriteArtists;
 use Illuminate\Http\Request;

--- a/app/Models/ShoppingCard.php
+++ b/app/Models/ShoppingCard.php
@@ -19,7 +19,7 @@ class ShoppingCard extends Model
 
     public function shoppingCardDetail()
     {
-        return $this->hasMany(shoppingCardDetail::class);
+        return $this->hasMany(ShoppingCardDetail::class);
     }
 
     public function user()

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,7 +54,6 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::resource('/admin/permissions', PermissionsApiController::class);
     Route::resource('/admin/musical-genders', MusicalsGendersController::class);
     Route::get('/admin/dashboard-overview', [DashboardStatsController::class, 'index']);
-    
     //Route for artist
     Route::post('/artist-new/up-date/{id}', [ArtistController::class, 'updateDetails']);
     Route::get('/artist-new/gallery', [ArtistController::class, 'artistGalleryIndex']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\Artist\ArtistSalesController;
 use App\Http\Controllers\ArtistRatingController;
 use App\Http\Controllers\ChatController;
 use App\Http\Controllers\Admin\DashboardStatsController;
+use App\Http\Controllers\Client\ClientDashboardController;
 
 // Routes for login without sesion
 Route::post('/login', [AuthController::class, 'login']);
@@ -53,7 +54,7 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::resource('/admin/permissions', PermissionsApiController::class);
     Route::resource('/admin/musical-genders', MusicalsGendersController::class);
     Route::get('/admin/dashboard-overview', [DashboardStatsController::class, 'index']);
-
+    
     //Route for artist
     Route::post('/artist-new/up-date/{id}', [ArtistController::class, 'updateDetails']);
     Route::get('/artist-new/gallery', [ArtistController::class, 'artistGalleryIndex']);
@@ -62,6 +63,7 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::delete('/artist-new/gallery-artist-delete', [ArtistController::class, 'deleteGaleryArtist']);
     Route::resource('/artist-new', ArtistController::class);
     //Route for client
+    Route::get('/client/dashboard-overview', [ClientDashboardController::class, 'index']);
     Route::resource('/client-card', ClientController::class);
     Route::get('/client/profile', [ClientController::class, 'getProfile']);
     Route::get('/client/musical-genders', [GendersController::class, 'index']);


### PR DESCRIPTION
This pull request introduces a new API endpoint that provides a dashboard overview for clients, aggregating information about their shopping cart, purchases, and favorite artists. The main changes are the addition of a new controller to handle this logic and the registration of a new route.

**New Client Dashboard Feature:**

* Added `ClientDashboardController` with an `index` method that:
  * Aggregates the current user's active shopping cart details, including items, total items, and total amount.
  * Summarizes the user's purchase history, including total purchases, total spent, and details of the last purchase.
  * Summarizes the user's favorite artists, including total favorites, how many were added in a given period, and sample favorite artists.
  * Returns all data in a structured JSON payload for frontend consumption.

**API Route Registration:**

* Registered the new controller in `routes/api.php` and added the `/client/dashboard-overview` GET route to expose the dashboard data. [[1]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR28) [[2]](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR66)