### PR TITLE
add sender relationship and update read status in chat controller

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -10,7 +10,13 @@ class ChatController extends Controller
 {
     public function getMessages($artistSaleId)
     {
-        $messages = Message::where('artist_sale_id', $artistSaleId)
+        Message::where('artist_sale_id', $artistSaleId)
+            ->where('created_by', '!=', Auth::id())
+            ->where('is_read', false)
+            ->update(['is_read' => true]);
+
+        $messages = Message::with('sender')
+            ->where('artist_sale_id', $artistSaleId)
             ->orderBy('created_at', 'asc')
             ->get();
 
@@ -34,6 +40,8 @@ class ChatController extends Controller
             'is_read' => false
         ]);
 
+        $message->load('sender');
+        
         return response()->json([
             'success' => true,
             'message' => $message


### PR DESCRIPTION
## Chat Message Read Status & Sender Information

### Changes Made
- Added logic to automatically mark unread messages as read when a user retrieves the conversation.
- Only messages that:
  - belong to the current `artist_sale_id`
  - were not created by the authenticated user
  - have `is_read = false`
  
  are updated to `is_read = true`.

### Message Retrieval Enhancement
- Updated the message query to eager-load the `sender` relationship using `with('sender')`.
- This allows each message to include sender information in the API response without additional queries.

### New Message Response Enhancement
- After creating a new message, the `sender` relationship is loaded using:
  ```php
  $message->load('sender');