### PR TITLE
fix: fixed the shoppingCardDetail::class to ShoppingCardDetail:class …

### DIFF
--- a/app/Models/ShoppingCard.php
+++ b/app/Models/ShoppingCard.php
@@ -19,7 +19,7 @@ class ShoppingCard extends Model
 
     public function shoppingCardDetail()
     {
-        return $this->hasMany(shoppingCardDetail::class);
+        return $this->hasMany(ShoppingCardDetail::class);
     }
 
     public function user()


### PR DESCRIPTION
Fix: Correct model reference casing in relationship definition
This PR updates the shoppingCardDetail relationship to use the correctly cased model name ShoppingCardDetail::class instead of the lowercase shoppingCardDetail::class.

Using the proper PascalCase class reference ensures:

Correct autoloading by PSR‑4

Consistency with Laravel naming conventions

Prevention of potential class‑not‑found errors

No functional logic was changed — only the class reference was corrected for proper syntax and consistency.