### PR TITLE
Add social media validation rule and fix cart cleanup query

### DIFF
--- a/app/Http/Controllers/Artist/ArtistController.php
+++ b/app/Http/Controllers/Artist/ArtistController.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use App\Rules\ValidSocialMedia;
 
 class ArtistController extends Controller
 {
@@ -229,6 +230,7 @@ class ArtistController extends Controller
                 'phone_manager'   => 'required',
                 'email_manager'   => 'required|email',
                 'image_manager'   => ['nullable', 'file', 'max:1024', new ValidImageUpload()],
+                'social_media' => ['nullable', new ValidSocialMedia()],
             ]);
 
             DB::beginTransaction();

--- a/app/Rules/ValidSocialMedia.php
+++ b/app/Rules/ValidSocialMedia.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class ValidSocialMedia implements Rule
+{
+    private string $errorMessage = '';
+
+    private array $domainMap = [
+        'Instagram'   => 'instagram.com',
+        'X (Twitter)' => 'twitter.com',
+        'YouTube'     => 'youtube.com',
+        'Facebook'    => 'facebook.com',
+        'TikTok'      => 'tiktok.com',
+        'Spotify'     => 'spotify.com',
+        'Apple Music' => 'music.apple.com',
+        'SoundCloud'  => 'soundcloud.com',
+        'Bandcamp'    => 'bandcamp.com',
+        'LinkedIn'    => 'linkedin.com',
+    ];
+
+    public function passes($attribute, $value): bool
+    {
+        $networks = is_string($value) ? json_decode($value, true) : $value;
+
+        foreach ($networks as $network) {
+            $nombre = $network['nombre'] ?? '';
+            $url    = $network['url'] ?? '';
+
+            if (empty($nombre) || empty($url)) {
+                $this->errorMessage = 'Cada red social debe tener nombre y URL.';
+                return false;
+            }
+
+            if (!filter_var($url, FILTER_VALIDATE_URL)) {
+                $this->errorMessage = "La URL de $nombre no es válida.";
+                return false;
+            }
+
+            $expectedDomain = $this->domainMap[$nombre] ?? null;
+            $actualHost     = parse_url($url, PHP_URL_HOST) ?? '';
+            $actualHost     = strtolower(str_replace('www.', '', $actualHost));
+
+            if ($expectedDomain && !str_contains($actualHost, $expectedDomain)) {
+                $this->errorMessage = "La URL de $nombre debe pertenecer a $expectedDomain.";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function message(): string
+    {
+        return $this->errorMessage;
+    }
+}

--- a/app/Rules/ValidSocialMedia.php
+++ b/app/Rules/ValidSocialMedia.php
@@ -10,7 +10,7 @@ class ValidSocialMedia implements Rule
 
     private array $domainMap = [
         'Instagram'   => 'instagram.com',
-        'X (Twitter)' => 'twitter.com',
+        'X (Twitter)' => 'x.com',
         'YouTube'     => 'youtube.com',
         'Facebook'    => 'facebook.com',
         'TikTok'      => 'tiktok.com',

--- a/app/Rules/ValidSocialMedia.php
+++ b/app/Rules/ValidSocialMedia.php
@@ -26,25 +26,25 @@ class ValidSocialMedia implements Rule
         $networks = is_string($value) ? json_decode($value, true) : $value;
 
         foreach ($networks as $network) {
-            $nombre = $network['nombre'] ?? '';
+            $name = $network['name'] ?? '';
             $url    = $network['url'] ?? '';
 
-            if (empty($nombre) || empty($url)) {
+            if (empty($name) || empty($url)) {
                 $this->errorMessage = 'Cada red social debe tener nombre y URL.';
                 return false;
             }
 
             if (!filter_var($url, FILTER_VALIDATE_URL)) {
-                $this->errorMessage = "La URL de $nombre no es válida.";
+                $this->errorMessage = "La URL de $name no es válida.";
                 return false;
             }
 
-            $expectedDomain = $this->domainMap[$nombre] ?? null;
+            $expectedDomain = $this->domainMap[$name] ?? null;
             $actualHost     = parse_url($url, PHP_URL_HOST) ?? '';
             $actualHost     = strtolower(str_replace('www.', '', $actualHost));
 
             if ($expectedDomain && !str_contains($actualHost, $expectedDomain)) {
-                $this->errorMessage = "La URL de $nombre debe pertenecer a $expectedDomain.";
+                $this->errorMessage = "La URL de $name debe pertenecer a $expectedDomain.";
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
This PR introduces a new custom validation rule for artist social media links and resolves a bug in the payment and cart cleanup logic.

## Changes Included
* **ArtistController:** Integrated the `ValidSocialMedia` rule into the artist creation/update validation process.
* **ValidSocialMedia:** Added a new custom rule to validate the incoming social media payloads.
* **PaymentController:** Optimized the `ShoppingCard` retrieval logic by replacing `get()` with `first()`, and refactored the cleanup process to handle a single active cart instance rather than looping through a collection.

## Impact
* Ensures that only valid social media URLs and expected domains are saved to the database for artists.
* Prevents potential iteration errors during the checkout phase by accurately targeting the user's single active shopping cart. 

## Why?
Previously, the cart cleanup process expected a collection but logically a user should only have one active cart at checkout. This streamlines the code and prevents bugs. Additionally, stricter validation for social media inputs ensures better data integrity across the platform.

## How to Test
1. Attempt to create or update an artist with invalid social media URLs; verify that the backend rejects the payload.
2. Complete a transaction and verify that the active shopping cart's details are deleted and its status is correctly updated to `2`.