### PR TITLE
Implement artist youtube videos management and API endpoints

### DIFF
--- a/app/Http/Controllers/Artist/ArtistController.php
+++ b/app/Http/Controllers/Artist/ArtistController.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use App\Rules\ValidSocialMedia;
+use App\Models\ArtistVideo;
 
 class ArtistController extends Controller
 {
@@ -461,6 +462,73 @@ class ArtistController extends Controller
             return response()->json([
                 'success' => true,
                 'artists' => $artistWithMusicalGender,
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 500);
+        }
+    }
+
+    public function artistVideosIndex()
+    {
+        try {
+            $artist_id = Artist::where('user_id', Auth::user()->id)->first();
+            $videos = ArtistVideo::where('artist_id', $artist_id->id)->get();
+
+            return response()->json([
+                'success' => true,
+                'artistVideos' => $videos,
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 500);
+        }
+    }
+
+    public function storeArtistVideo(Request $request)
+    {
+        try {
+            $artist = Artist::where('user_id', Auth::user()->id)->first();
+            $count = ArtistVideo::where('artist_id', $artist->id)->count();
+
+            if ($count >= 3) {
+                return response()->json(['message' => 'Máximo 3 videos permitidos'], 422);
+            }
+
+            $url = $request->youtube_url;
+            preg_match('/(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/', $url, $matches);
+
+            if (empty($matches[1])) {
+                return response()->json(['message' => 'URL de YouTube no válida'], 422);
+            }
+
+            $video = ArtistVideo::create([
+                'artist_id'   => $artist->id,
+                'youtube_url' => $matches[1],
+                'title'       => $oembed['title'] ?? null,
+                'thumbnail'   => $oembed['thumbnail_url'] ?? "https://img.youtube.com/vi/{$matches[1]}/hqdefault.jpg",
+            ]);
+
+            return response()->json(['success' => true, 'artistVideo' => $video], 201);
+        } catch (\Exception $e) {
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
+    }
+
+    public function deleteArtistVideo($id)
+    {
+        try {
+            $artist = Artist::where('user_id', Auth::user()->id)->first();
+            $video = ArtistVideo::where('id', $id)->where('artist_id', $artist->id)->firstOrFail();
+            $video->delete();
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Video eliminado',
             ], 200);
         } catch (\Exception $e) {
             return response()->json([

--- a/app/Models/ArtistVideo.php
+++ b/app/Models/ArtistVideo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ArtistVideo extends Model
+{
+    protected $fillable = ['artist_id', 'youtube_url'];
+}

--- a/database/migrations/2026_06_10_000000_create_artist_videos_table.php
+++ b/database/migrations/2026_06_10_000000_create_artist_videos_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateArtistVideosTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('artist_videos', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('artist_id')->nullable();
+            $table->string('youtube_url');
+            $table->timestamps();
+        });
+        Schema::table('artist_videos', function (Blueprint $table) {
+            $table->foreign('artist_id')->references('id')->on('artists')->onDelete('set null');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('artist_videos');
+    }
+}

--- a/database/migrations/database/migrations/2026_06_10_000001_add_preview_to_artist_videos_table.php
+++ b/database/migrations/database/migrations/2026_06_10_000001_add_preview_to_artist_videos_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPreviewToArtistVideosTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('artist_videos', function (Blueprint $table) {
+            $table->string('title')->nullable()->after('youtube_url');
+            $table->string('thumbnail')->nullable()->after('title');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('artist_videos', function (Blueprint $table) {
+            $table->dropColumn(['title', 'thumbnail']);
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -58,6 +58,9 @@ Route::group(["middleware" => "auth:api"], function () {
     //Route for artist
     Route::post('/artist-new/up-date/{id}', [ArtistController::class, 'updateDetails']);
     Route::get('/artist-new/gallery', [ArtistController::class, 'artistGalleryIndex']);
+    Route::get('/artist-new/videos', [ArtistController::class, 'artistVideosIndex']);
+    Route::post('/artist-new/videos', [ArtistController::class, 'storeArtistVideo']);
+    Route::delete('/artist-new/videos/{id}', [ArtistController::class, 'deleteArtistVideo']);
     Route::post('/artist-new/gallery-artist', [ArtistController::class, 'storeGaleryArtist']);
     Route::post('/artist-new/gallery-artist-update', [ArtistController::class, 'updateGaleryArtist']);
     Route::delete('/artist-new/gallery-artist-delete', [ArtistController::class, 'deleteGaleryArtist']);


### PR DESCRIPTION
## Summary
This PR introduces the backend infrastructure and API endpoints required for artists to manage their YouTube video gallery. It includes the database migration, Eloquent model, and controller logic.

## Changes Included
* **Database & Models:** Created the `artist_videos` migration and the corresponding `ArtistVideo` model.
* **Routes:** Added new protected API routes under `/artist-new/videos` for `GET`, `POST`, and `DELETE` requests.
* **ArtistController:**
  * `artistVideosIndex`: Fetches all videos associated with the authenticated artist.
  * `storeArtistVideo`: Validates the YouTube URL, extracts the video ID via regex, ensures the artist hasn't exceeded the maximum limit of 3 videos, and saves the record.
  * `deleteArtistVideo`: Safely removes a specific video belonging to the authenticated artist.

## Impact
* **New Feature:** Grants artists the capability to link up to 3 YouTube videos to their profile.
* **Data Integrity:** Employs regex validation to ensure only valid YouTube URLs/IDs are saved to the database.

## Why?
To enhance the artist profiles by allowing them to showcase multimedia content directly from YouTube. The 3-video limit ensures the profile loads efficiently and storage remains optimized, while regex validation prevents malformed URLs from breaking the frontend UI.

## How to Test
1. Run `php artisan migrate` to create the new `artist_videos` table.
2. Authenticate as an artist and hit `GET /api/artist-new/videos` to verify an empty array is returned.
3. Hit `POST /api/artist-new/videos` with a payload containing `{"youtube_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"}`. Verify the response is `201 Created`.
4. Attempt to add a 4th video to trigger the 422 limit validation.
5. Hit `DELETE /api/artist-new/videos/{id}` and verify the video is successfully removed.