### PR TITLE
Feature: Improve payment reference management and add PDF/image download support

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -663,6 +663,7 @@ class PaymentController extends Controller
                     $sale->event_date             = $item['event_date'];
                     $sale->event_hour             = $item['event_hour'];
                     $sale->payment_method = 'cash';
+                    $sale->store = $store;
                     $sale->save();
                 }
 
@@ -764,8 +765,6 @@ class PaymentController extends Controller
             $barcodeUrl = $charge->payment_method->barcode_url ?? null;
             $dueDateStr = $dueDateInstance->toDateTimeString();
 
-            $store = $request->input('store', 'Tienda');
-
             $relatedSales = ArtistSale::where('customer_id', $sale->customer_id)
                 ->where('openpay_transaction_id', $sale->openpay_transaction_id)
                 ->get();
@@ -780,7 +779,7 @@ class PaymentController extends Controller
                     'id'        => $charge->id,
                     'amount'    => $charge->amount,
                     'status'    => $charge->status,
-                    'store'     => $store,
+                    'store'     => $sale->store ?? 'Tienda',
                     'reference' => $cashRef,
                     'barcode'   => $barcodeUrl,
                     'due_date'  => $dueDateStr,

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -556,7 +556,7 @@ class PaymentController extends Controller
             $openpay = Openpay::getInstance($keys->openpay_id, $keys->openpay_secret, "MX");
             Openpay::setProductionMode(false);
 
-            $dueDateInstance = Carbon::now()->addDays(3);
+            $dueDateInstance = Carbon::now()->addHours(24);
 
             $name        = $request->input('order_details.first_name') ?? $request->input('customer_name');
             $last_name   = $request->input('order_details.last_name', '');
@@ -638,7 +638,7 @@ class PaymentController extends Controller
                 'currency'    => 'MXN',
                 'description' => 'Reserva artista - Pago en efectivo (' . $store . ')',
                 'customer'    => $customerData,
-                'due_date'    => Carbon::now()->addDays(3)->format('Y-m-d\TH:i:s'),
+                'due_date'    => Carbon::now()->addHours(24)->format('Y-m-d\TH:i:s'),
             ];
 
             $charge = $openpay->charges->create($chargeRequest);
@@ -662,6 +662,7 @@ class PaymentController extends Controller
                     $sale->customer_zip_code      = $zip_code;
                     $sale->event_date             = $item['event_date'];
                     $sale->event_hour             = $item['event_hour'];
+                    $sale->payment_method = 'cash';
                     $sale->save();
                 }
 
@@ -693,6 +694,99 @@ class PaymentController extends Controller
                 'message'   => 'Referencia de pago generada correctamente',
             ]);
 
+        } catch (OpenpayApiTransactionError $e) {
+            return response()->json(['error' => ['category' => $e->getCategory(), 'error_code' => $e->getErrorCode(), 'description' => $e->getMessage()]], 500);
+        } catch (OpenpayApiRequestError $e) {
+            return response()->json(['error' => ['category' => $e->getCategory(), 'error_code' => $e->getErrorCode(), 'description' => $e->getMessage()]], 500);
+        } catch (OpenpayApiConnectionError $e) {
+            return response()->json(['error' => ['category' => $e->getCategory(), 'error_code' => $e->getErrorCode(), 'description' => $e->getMessage()]], 500);
+        } catch (OpenpayApiAuthError $e) {
+            return response()->json(['error' => ['category' => $e->getCategory(), 'error_code' => $e->getErrorCode(), 'description' => $e->getMessage()]], 500);
+        } catch (OpenpayApiError $e) {
+            return response()->json(['error' => ['category' => $e->getCategory(), 'error_code' => $e->getErrorCode(), 'description' => $e->getMessage()]], 500);
+        } catch (Exception $e) {
+            return response()->json(['error' => ['category' => 'Generic Error', 'error_code' => 'GENERIC_ERROR', 'description' => $e->getMessage()]], 500);
+        }
+    }
+
+    public function regenerateCashReference(Request $request)
+    {
+        try {
+            $saleId = $request->input('artist_sale_id');
+            if (!$saleId) {
+                return response()->json(['error' => 'Se requiere el ID de la venta'], 400);
+            }
+
+            $sale = ArtistSale::where('id', $saleId)
+                ->where('payment_method', 'cash')
+                ->first();
+
+            if (!$sale) {
+                return response()->json(['error' => 'Venta no encontrada o no es un pago en efectivo'], 404);
+            }
+
+            if ($sale->status === 'completed') {
+                return response()->json(['error' => 'Esta venta ya fue pagada'], 400);
+            }
+
+            $keys = OpenpayKey::first();
+            $openpay = Openpay::getInstance($keys->openpay_id, $keys->openpay_secret, "MX");
+            Openpay::setProductionMode(false);
+
+            $dueDateInstance = Carbon::now()->addHours(24);
+
+            $customerData = [
+                'name'             => $sale->customer_first_name,
+                'last_name'        => $sale->customer_last_name,
+                'email'            => $sale->customer_email,
+                'requires_account' => false,
+                'address'          => [
+                    'line1'        => $sale->customer_address ?? 'Sin dirección',
+                    'city'         => $sale->customer_city ?? 'Ciudad',
+                    'state'        => $sale->customer_state ?? 'Estado',
+                    'postal_code'  => $sale->customer_zip_code ?? '00000',
+                    'country_code' => 'MX',
+                ],
+            ];
+
+            $chargeRequest = [
+                'method'      => 'store',
+                'amount'      => (float) $sale->amount,
+                'currency'    => 'MXN',
+                'description' => 'Re-generación referencia - Reserva artista',
+                'customer'    => $customerData,
+                'due_date'    => $dueDateInstance->format('Y-m-d\TH:i:s'),
+            ];
+
+            $charge = $openpay->charges->create($chargeRequest);
+
+            $cashRef = $charge->payment_method->reference ?? null;
+            $barcodeUrl = $charge->payment_method->barcode_url ?? null;
+            $dueDateStr = $dueDateInstance->toDateTimeString();
+
+            $store = $request->input('store', 'Tienda');
+
+            $relatedSales = ArtistSale::where('customer_id', $sale->customer_id)
+                ->where('openpay_transaction_id', $sale->openpay_transaction_id)
+                ->get();
+
+            foreach ($relatedSales as $related) {
+                $related->openpay_transaction_id = $charge->id;
+                $related->save();
+            }
+
+            return response()->json([
+                'data' => [
+                    'id'        => $charge->id,
+                    'amount'    => $charge->amount,
+                    'status'    => $charge->status,
+                    'store'     => $store,
+                    'reference' => $cashRef,
+                    'barcode'   => $barcodeUrl,
+                    'due_date'  => $dueDateStr,
+                ],
+                'message' => 'Nueva referencia generada correctamente',
+            ]);
         } catch (OpenpayApiTransactionError $e) {
             return response()->json(['error' => ['category' => $e->getCategory(), 'error_code' => $e->getErrorCode(), 'description' => $e->getMessage()]], 500);
         } catch (OpenpayApiRequestError $e) {

--- a/app/Models/ArtistSale.php
+++ b/app/Models/ArtistSale.php
@@ -24,6 +24,7 @@ class ArtistSale extends Model
         'event_hours',
         'event_status',
         'openpay_transaction_id',
+        'payment_method',
     ];
 
     public function artist()

--- a/app/Models/ArtistSale.php
+++ b/app/Models/ArtistSale.php
@@ -25,6 +25,7 @@ class ArtistSale extends Model
         'event_status',
         'openpay_transaction_id',
         'payment_method',
+        'store',
     ];
 
     public function artist()

--- a/database/migrations/2026_06_12_000002_add_cash_reference_fields_to_artist_sales_table.php
+++ b/database/migrations/2026_06_12_000002_add_cash_reference_fields_to_artist_sales_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('artist_sales', function (Blueprint $table) {
+            if (!Schema::hasColumn('artist_sales', 'payment_method')) {
+                $table->string('payment_method')->nullable()->after('event_status');
+            }
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('artist_sales', function (Blueprint $table) {
+            if (Schema::hasColumn('artist_sales', 'payment_method')) {
+                $table->dropColumn('payment_method');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_06_12_000002_add_cash_reference_fields_to_artist_sales_table.php
+++ b/database/migrations/2026_06_12_000002_add_cash_reference_fields_to_artist_sales_table.php
@@ -12,14 +12,20 @@ return new class extends Migration
             if (!Schema::hasColumn('artist_sales', 'payment_method')) {
                 $table->string('payment_method')->nullable()->after('event_status');
             }
+            if (!Schema::hasColumn('artist_sales', 'store')) {
+                $table->string('store')->nullable()->after('payment_method');
+            }
         });
     }
 
     public function down()
     {
         Schema::table('artist_sales', function (Blueprint $table) {
-            if (Schema::hasColumn('artist_sales', 'payment_method')) {
-                $table->dropColumn('payment_method');
+            $columns = ['payment_method', 'store'];
+            foreach ($columns as $column) {
+                if (Schema::hasColumn('artist_sales', $column)) {
+                    $table->dropColumn($column);
+                }
             }
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -118,6 +118,7 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::post('/process-payment', [ClientPaymentController::class, 'processPayment']);
     Route::get('/artist-sales', [PaymentController::class, 'getSalesByArtist']);
     Route::post('/payment/cash', [PaymentController::class, 'processCashPayment']);
+    Route::post('/payment/cash/regenerate', [PaymentController::class, 'regenerateCashReference']);
     Route::post('/payment/confirm/{transactionId}', [PaymentController::class, 'confirmPayment']);
     Route::get('/client/last-order', [PaymentController::class, 'getLastClientOrder']);
     Route::get('/artist/sales/details', [PaymentController::class, 'getArtistSalesDetails']);


### PR DESCRIPTION
**Summary**

This PR enhances the cash payment reference experience by improving its visual presentation and adding new download options.

Users can now download their payment reference as a PDF or image during the checkout process and re-download it later from the My Purchases module.

Additionally, new fields were added to store payment reference information associated with cash payments, allowing references to be preserved and accessed after purchase creation.

**Changes Implemented**

🔹 Payment Reference Improvements

- Redesigned the payment reference layout and presentation.
- Improved readability of payment information.
- Enhanced the overall user experience for cash payment references.

🔹 Download Functionality

- Added the ability to download payment references as:
- PDF
- Image
- Enabled re-downloading of payment references from the My Purchases module.
- Improved accessibility of payment documentation after checkout.

🔹 Backend Enhancements

- Added support for storing payment reference-related information in artist_sales.
- Updated payment processing logic to handle reference generation and retrieval.
- Extended API functionality to support payment reference management.

🔹 Frontend Enhancements

- Integrated PDF and image generation/download functionality.
- Updated purchase detail screens to display and manage payment references.
- Improved checkout flow for cash payment methods.

📁 Files Modified

Controllers

- app/Http/Controllers/PaymentController.php

Models

- app/Models/ArtistSale.php

Migrations

- database/migrations/2026_06_12_000002_add_cash_reference_fields_to_artist_sales_table.php

Routes

- routes/api.php