### PR TITLE
fix(user-validation): translate duplicate email error message to Spanish

### DIFF
--- a/app/Http/Requests/User/UserApiCreateRequest.php
+++ b/app/Http/Requests/User/UserApiCreateRequest.php
@@ -40,4 +40,10 @@ class UserApiCreateRequest extends FormRequest
             'role_id' => 'rol del usuario'
         ];
     }
+    public function messages(): array
+    {
+        return [
+            'email.unique' => 'El correo del usuario ya se encuentra registrado.',
+        ];
+    }
 }


### PR DESCRIPTION
## Description
Translated the database duplication error message for the user's email from English to Spanish. This ensures consistency with the frontend language and improves the user experience when a registration conflict occurs.

## Changes Made
- Added a custom `messages()` method in `UserApiCreateRequest.php`.
- Customized the `email.unique` validation rule to return the message in Spanish: *"El correo del usuario ya se encuentra registrado."*

## How to Test
1. Go to the Admin Users section in the frontend (`/admin/users`).
2. Try to create a new user using an email address that already exists in the database.
3. Verify that the Quasar notification now displays the error message clearly in Spanish.
<img width="1440" height="900" alt="Captura de pantalla de 2026-06-15 12-51-54" src="https://github.com/user-attachments/assets/8564bfef-0011-45af-ae38-42890f2399ca" />

