### PR TITLE
fix(musical-genders): add manual validator to prevent duplicate entries

### DIFF
--- a/app/Http/Controllers/Admin/MusicalsGendersController.php
+++ b/app/Http/Controllers/Admin/MusicalsGendersController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\MusicalGender;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -48,8 +49,26 @@ class MusicalsGendersController extends Controller
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
+
     public function store(Request $request)
     {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255|unique:musical_genders,name',
+            'description' => 'required|string',
+            'color' => 'required|string',
+        ], [
+            'name.unique' => 'El género musical ya se encuentra registrado.',
+            'name.required' => 'El nombre del género es obligatorio.',
+        ]);
+
+        
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => $validator->errors()->first() 
+            ], 422);
+        }
+        
         try {
             $slug = Str::slug($request->input('name'));
             DB::beginTransaction();
@@ -105,8 +124,25 @@ class MusicalsGendersController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
+    
     public function update(Request $request, $id)
     {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255|unique:musical_genders,name,' . $id,
+            'description' => 'required|string',
+            'color' => 'required|string',
+        ], [
+            'name.unique' => 'El género musical ya se encuentra registrado.',
+            'name.required' => 'El nombre del género es obligatorio.',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => $validator->errors()->first()
+            ], 422);
+        }
+
         try {
             $slug = Str::slug($request->input('name'));
             DB::beginTransaction();

--- a/app/Http/Controllers/Admin/MusicalsGendersController.php
+++ b/app/Http/Controllers/Admin/MusicalsGendersController.php
@@ -61,7 +61,6 @@ class MusicalsGendersController extends Controller
             'name.required' => 'El nombre del género es obligatorio.',
         ]);
 
-        
         if ($validator->fails()) {
             return response()->json([
                 'success' => false,
@@ -124,7 +123,7 @@ class MusicalsGendersController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    
+
     public function update(Request $request, $id)
     {
         $validator = Validator::make($request->all(), [


### PR DESCRIPTION
## Description
Implemented backend validation for the musical genders resource to prevent duplicate entries in the database. This acts as a security measure and ensures data integrity even if the frontend validation is bypassed.

## Changes Made
- Added a manual `Validator` instance in both `store` and `update` methods inside `MusicalsGendersController.php`.
- Enforced a `unique` rule on the `name` column, ignoring the current ID during updates.
- Configured custom messages in Spanish to match the system language.
- Returned a proper `422 Unprocessable Content` HTTP status code when validation fails.

## How to Test
1. Send a POST request to `/api/admin/musical-genders` using Postman with a name that already exists.
2. Verify it returns a `422` status code and the message: *"El género musical ya se encuentra registrado."*