### PR TITLE
feat(login): add rate limit for 300s when the user send wrong credent…

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
 
 class AuthController extends Controller
 {
@@ -21,13 +23,37 @@ class AuthController extends Controller
      */
     public function login(Request $request)
     {
+        $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        $throttleKey = Str::lower($request->input('email')) . '|' . $request->ip();
+
+        if (RateLimiter::tooManyAttempts($throttleKey, 3)) {
+            $seconds = RateLimiter::availableIn($throttleKey);
+            $minutesLeft = ceil($seconds / 60);
+
+            return response()->json([
+                'success' => false,
+                'error' => "Demasiados intentos. Intenta de nuevo en {$minutesLeft} minutos."
+            ], 429);
+        }
+
         $credentials = $request->only('email', 'password');
 
         if ($token = Auth::attempt($credentials)) {
+            RateLimiter::clear($throttleKey);
+            
             return $this->respondWithToken($token);
         }
 
-        return response()->json(['error' => 'Las credenciales no corresponden a ningún usuario'], 401);
+        RateLimiter::hit($throttleKey, 300);
+
+        return response()->json([
+            'success' => false,
+            'error' => 'Las credenciales no corresponden a ningún usuario'
+        ], 401);
     }
 
     /**
@@ -76,7 +102,7 @@ class AuthController extends Controller
             'success' => true,
             'access_token' => $token,
             'token_type' => 'bearer',
-            'expires_in' => auth()->factory()->getTTL() * null
+            'expires_in' => auth()->factory()->getTTL() * 60
         ]);
     }
 }


### PR DESCRIPTION
## Description
Implemented a native backend Rate Limiting mechanism for the authentication system to enhance security against brute-force attacks. As requested, users are now restricted to a maximum of 3 failed login attempts, after which they will be locked out for 5 minutes. 

This implementation utilizes Laravel's default cache driver and does not require any additional database modifications or tables.

## Changes Made
- Added `Illuminate\Support\Facades\RateLimiter` to handle login throttling statically.
- Created a unique throttle key based on the combination of the client's `email` (normalized to lowercase) and their current `IP` address.
- Configured a restriction threshold of `5 attempts` maximum.
- Set a lockout decay time of `300 seconds` (5 minutes) using `RateLimiter::hit()`.
- Returned a proper `429 Too Many Requests` HTTP status code containing the remaining minutes left once a user is locked out.
- Ensured successful authentications reset the attempt counter using `RateLimiter::clear()`.

## How to Test
1. Go to the login screen or use an API client like Postman to target the `POST /api/auth/login` endpoint.
2. Attempt to sign in 3 consecutive times with valid email addresses but wrong/invalid passwords.
3. On the 4th attempt, verify that the backend responds with an HTTP status `429` and a JSON response stating: *"Demasiados intentos. Por seguridad. Intenta de nuevo en 5 minutos."*
4. Wait 5 minutes or flush the application cache to verify the lockout naturally expires.