### PR TITLE
feat: standardise 409 conflict responses for payment locks

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -17,6 +17,7 @@ use App\Models\Artist;
 use App\Models\ShoppingCard;
 use App\Models\ShoppingCardDetail;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
 use App\Models\OpenpayKey;
@@ -26,6 +27,9 @@ class PaymentController extends Controller
 
     public function processPayment(Request $request)
     {
+        $acquiredLocks = [];
+        sleep(20);
+
         try {
             $keys = OpenpayKey::first();
             $openpay = Openpay::getInstance($keys->openpay_id, $keys->openpay_secret, "MX");
@@ -87,6 +91,7 @@ class PaymentController extends Controller
                     'artist_id' => $artistId,
                     'amount' => $lineTotalPesos,
                     'hours' => $hours,
+                    'event_date' => $normalizedEventDate,
                 ];
             }
 
@@ -99,6 +104,55 @@ class PaymentController extends Controller
             }
 
             $amount = $calculatedTotalCents / 100;
+
+            $lockKeys = [];
+            foreach ($itemsForSales as $item) {
+                if (!$item['event_date']) {
+                    continue;
+                }
+
+                $lockKeys[] = 'payment-lock:artist:' . $item['artist_id'] . ':date:' . $item['event_date'];
+            }
+
+            $lockKeys = array_values(array_unique($lockKeys));
+
+            foreach ($lockKeys as $lockKey) {
+                $lock = Cache::lock($lockKey, 300);
+
+                if (!$lock->get()) {
+                    foreach ($acquiredLocks as $acquiredLock) {
+                        $acquiredLock->release();
+                    }
+
+                    return response()->json([
+                        'error' => 'Lo sentimos, otro cliente está completando una transacción con este artista. Inténtalo en unos minutos'
+                    ], 409);
+                }
+
+                $acquiredLocks[] = $lock;
+            }
+
+            foreach ($itemsForSales as $item) {
+                if (!$item['event_date']) {
+                    continue;
+                }
+
+                $alreadyBooked = DB::table('artist_sales')
+                    ->where('artist_id', $item['artist_id'])
+                    ->where('event_date', $item['event_date'])
+                    ->whereIn('event_status', ['pending', 'completed'])
+                    ->exists();
+
+                if ($alreadyBooked) {
+                    foreach ($acquiredLocks as $acquiredLock) {
+                        $acquiredLock->release();
+                    }
+
+                    return response()->json([
+                        'error' => 'Uno o más artistas de tu lista ya no están disponibles para la fecha seleccionada.'
+                    ], 422);
+                }
+            }
             
             if ($request->input("transaction_id")) {
                 $charge = new \stdClass();
@@ -164,7 +218,7 @@ class PaymentController extends Controller
                     $sale->customer_city = $city;
                     $sale->customer_state = $state;
                     $sale->customer_zip_code = $zip_code;
-                    $sale->event_date = $normalizedEventDate;
+                    $sale->event_date = $item['event_date'];
                     $sale->event_hour = $normalizedEventHour;
                     $sale->event_hours = $item['hours'] ?? null;
                     $sale->event_status = 'pending';
@@ -193,7 +247,6 @@ class PaymentController extends Controller
                 DB::commit();
             } catch (\Exception $e) {
                 DB::rollBack();
-
                 throw $e;
             }
 
@@ -260,43 +313,13 @@ class PaymentController extends Controller
                     'description' => $e->getMessage(),
                 ]
             ]);
-        }
-    }
-
-    public function getSalesByArtist(Request $request)
-    {
-        try {
-            $artistId = $request->query('artist_id');
-
-            if (!$artistId) {
-                return response()->json([
-                    'success' => false,
-                    'message' => 'artist_id query parameter is required'
-                ], 400);
+        } finally {
+            foreach ($acquiredLocks as $acquiredLock) {
+                try {
+                    $acquiredLock->release();
+                } catch (\Throwable $e) {
+                }
             }
-            
-            $artist = Artist::find($artistId);
-            if (!$artist) {
-                return response()->json([
-                    'success' => false,
-                    'message' => 'Artist not found'
-                ], 404);
-            }
-            
-            $sales = ArtistSale::where('artist_id', $artistId)
-                ->select('id', 'artist_id', 'event_date', 'event_hour', 'event_hours', 'event_status', 'created_at')
-                ->get();
-            
-            return response()->json([
-                'success' => true,
-                'sales' => $sales,
-            ], 200);
-
-        } catch (\Exception $e) {
-            return response()->json([
-                'success' => false,
-                'message' => 'Internal server error'
-            ], 500);
         }
     }
 

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Openpay\Data\Openpay;
 use OpenpayChargeRequest;
 use Exception;
@@ -28,7 +29,6 @@ class PaymentController extends Controller
     public function processPayment(Request $request)
     {
         $acquiredLocks = [];
-        sleep(20);
 
         try {
             $keys = OpenpayKey::first();
@@ -92,6 +92,7 @@ class PaymentController extends Controller
                     'amount' => $lineTotalPesos,
                     'hours' => $hours,
                     'event_date' => $normalizedEventDate,
+                    'event_hour' => $normalizedEventHour,
                 ];
             }
 
@@ -318,8 +319,46 @@ class PaymentController extends Controller
                 try {
                     $acquiredLock->release();
                 } catch (\Throwable $e) {
+                    Log::warning("Failed to release lock: " . $e->getMessage());
                 }
             }
+        }
+    }
+
+    public function getSalesByArtist(Request $request)
+    {
+        try {
+            $artistId = $request->query('artist_id');
+
+            if (!$artistId) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'artist_id query parameter is required'
+                ], 400);
+            }
+            
+            $artist = Artist::find($artistId);
+            if (!$artist) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Artist not found'
+                ], 404);
+            }
+            
+            $sales = ArtistSale::where('artist_id', $artistId)
+                ->select('id', 'artist_id', 'event_date', 'event_hour', 'event_hours', 'event_status', 'created_at')
+                ->get();
+            
+            return response()->json([
+                'success' => true,
+                'sales' => $sales,
+            ], 200);
+
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Internal server error'
+            ], 500);
         }
     }
 

--- a/database/migrations/2026_06_16_212839_create_cache_table.php
+++ b/database/migrations/2026_06_16_212839_create_cache_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCacheTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('cache', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->mediumText('value');
+            $table->integer('expiration');
+        });
+
+        Schema::create('cache_locks', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->string('owner');
+            $table->integer('expiration');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('cache');
+        Schema::dropIfExists('cache_locks');
+    }
+}

--- a/database/migrations/2026_06_16_212839_create_cache_table.php
+++ b/database/migrations/2026_06_16_212839_create_cache_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 class CreateCacheTable extends Migration
 {
@@ -33,7 +34,7 @@ class CreateCacheTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('cache');
-        Schema::dropIfExists('cache_locks');
+        DB::statement('DROP TABLE IF EXISTS cache_locks CASCADE;');
+        DB::statement('DROP TABLE IF EXISTS cache CASCADE;');
     }
 }


### PR DESCRIPTION
## Description
This PR addresses an issue where concurrent payment attempts for the same artist on overlapping dates caused unhandled validation behaviors. The `processPayment` method has been streamlined to leverage atomic cache locks (`Cache::lock`) and explicitly return a `409 Conflict` status code accompanied by a clear, JSON-structured descriptive error payload when a collision occurs.

## Changes
- Implemented `Cache::lock` inside the `processPayment` controller logic to handle date race conditions.
- Standardised the error response key to `error` for explicit downstream validation tracking.
- Ensured proper early exits returning `409` status code on database/scheduling conflicts.