### PR TITLE
fix(offers): restrict max discount percentage to 90 percent in larave…

### DIFF
--- a/app/Http/Controllers/Artist/OfferController.php
+++ b/app/Http/Controllers/Artist/OfferController.php
@@ -27,7 +27,7 @@ class OfferController extends Controller
         try {
             $request->validate([
                 'description'         => 'required|string',
-                'discount_percentage' => 'required|numeric|min:1|max:100',
+                'discount_percentage' => 'required|numeric|min:1|max:90',
                 'start_date'          => 'required|date',
                 'end_date'            => 'required|date|after:start_date',
             ]);
@@ -54,7 +54,7 @@ class OfferController extends Controller
         try {
             $request->validate([
                 'description'         => 'required|string',
-                'discount_percentage' => 'required|numeric|min:1|max:100',
+                'discount_percentage' => 'required|numeric|min:1|max:90', 
                 'start_date'          => 'required|date',
                 'end_date'            => 'required|date|after:start_date',
             ]);


### PR DESCRIPTION
## Description
This PR tightens server-side data integrity by reducing the maximum allowed value for the `discount_percentage` field from 100% down to a strict 90% cap. This prevents artists from creating free service contracts that would fail openpay/gateway transaction flows.

## Changes Made
- **Store Method Validation:** Updated the `store()` request validation schema inside `OfferController.php`, replacing `max:100` with `max:90` for the `discount_percentage` key.
- **Update Method Validation:** Applied the exact same `max:90` constraint inside the controller's `update()` method to securely handle any update payloads.

## How to Test
1. Use an API client like Postman or Insomnia to simulate an offer creation.
2. Send a POST request to the store endpoint with a body containing `"discount_percentage": 100`.
3. Verify that the Laravel Validator catches the payload, rejects it with a validation error exception, and blocks database persistence.
4. Repeat the test with a value of `90` and verify it passes successfully.