### PR TITLE
Feature: Format seeded card numbers with four-digit separators

### DIFF
--- a/database/seeders/CardSeeder.php
+++ b/database/seeders/CardSeeder.php
@@ -23,12 +23,12 @@ class CardSeeder extends Seeder
         })->orderBy('id')->get();
 
         $cards = [
-            ['type' => 'Visa', 'number' => '4111111111111111'],
-            ['type' => 'Mastercard', 'number' => '5555555555554444'],
-            ['type' => 'American Express', 'number' => '378282246310005'],
-            ['type' => 'Discover', 'number' => '6011111111111117'],
-            ['type' => 'Visa', 'number' => '4012888888881881'],
-            ['type' => 'Mastercard', 'number' => '5105105105105100'],
+            ['type' => 'Visa', 'number' => '4111-1111-1111-1111'],
+            ['type' => 'Mastercard', 'number' => '5555-5555-5555-4444'],
+            ['type' => 'American Express', 'number' => '3782-822463-10005'],
+            ['type' => 'Discover', 'number' => '6011-1111-1111-1117'],
+            ['type' => 'Visa', 'number' => '4012-8888-8888-1881'],
+            ['type' => 'Mastercard', 'number' => '5105-1051-0510-5100'],
         ];
 
         foreach ($users as $index => $user) {


### PR DESCRIPTION
**Summary**

This PR updates the card generation logic used in the seeder to format card numbers with a hyphen (-) every four digits.

The new format improves readability and provides a more realistic representation of card numbers within development and testing environments.

**📁 Files Modified**
Backend

Seeders

- database/seeders/CardSeeder.php