### PR TITLE
Add validation rules for role and music genre descriptions

### DIFF
--- a/app/Http/Controllers/Admin/MusicalsGendersController.php
+++ b/app/Http/Controllers/Admin/MusicalsGendersController.php
@@ -54,7 +54,7 @@ class MusicalsGendersController extends Controller
     {
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255|unique:musical_genders,name',
-            'description' => 'required|string',
+            'description' => 'required|string|min:10',
             'color' => 'required|string',
         ], [
             'name.unique' => 'El género musical ya se encuentra registrado.',
@@ -128,7 +128,7 @@ class MusicalsGendersController extends Controller
     {
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255|unique:musical_genders,name,' . $id,
-            'description' => 'required|string',
+            'description' => 'required|string|min:10',
             'color' => 'required|string',
         ], [
             'name.unique' => 'El género musical ya se encuentra registrado.',

--- a/app/Http/Controllers/RolesApiController.php
+++ b/app/Http/Controllers/RolesApiController.php
@@ -60,6 +60,14 @@ class RolesApiController extends Controller
                 ], 422);
             }
 
+            $description = $request->input('description');
+            if (strlen($description) < 10) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'La descripción debe tener al menos 10 caracteres'
+                ], 422);
+            }
+
             DB::beginTransaction();
 
             $slug = Str::slug($name);
@@ -138,6 +146,14 @@ class RolesApiController extends Controller
                 return response()->json([
                     'success' => false,
                     'message' => 'Ya existe un rol con ese nombre'
+                ], 422);
+            }
+
+            $description = $request->input('description');
+            if (strlen($description) < 10) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'La descripción debe tener al menos 10 caracteres'
                 ], 422);
             }
 


### PR DESCRIPTION
**Summary**

This PR improves consistency across the administration module by standardizing the appearance and behavior of the Create and Save buttons.

Additionally, validation rules were added to the description fields of Roles and Musical Genres, ensuring that the information entered by administrators meets the required standards before being saved.

**📁 Files Modified**

Backend

- Validation and administration-related logic (as applicable).