### PR TITLE
feature(backend): Add AdminPayout endpoints and update payout query l…

### DIFF
--- a/app/Http/Controllers/Admin/AdminPayoutController.php
+++ b/app/Http/Controllers/Admin/AdminPayoutController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\ArtistSale;
+use Illuminate\Http\JsonResponse;
+
+class AdminPayoutController extends Controller
+{
+    public function pendingPayouts(): JsonResponse
+    {
+        $sales = ArtistSale::with(['artist.payoutMethod'])
+            ->where('status', 'completed')
+            ->get();
+
+        $formattedPayouts = $sales->map(function ($sale) {
+            $amount = floatval($sale->amount);
+            $openpayFee = floatval($sale->openpay_fee);
+            $platformFee = $amount * 0.10;
+            $netArtistPayout = $amount - $openpayFee - $platformFee;
+
+            return [
+                'sale_id' => $sale->id,
+                'amount' => $amount,
+                'openpay_fee' => $openpayFee,
+                'platform_fee' => $platformFee,
+                'net_artist_payout' => max(0, $netArtistPayout), 
+                'event_date' => $sale->event_date,
+                'event_hour' => $sale->event_hour,
+                'event_status' => $sale->event_status,
+                'artist' => [
+                    'id' => $sale->artist->id,
+                    'name' => $sale->artist->name,
+                    'payout_method' => $sale->artist->payoutMethod ? [
+                        'bank_name' => $sale->artist->payoutMethod->bank_name,
+                        'account_holder' => $sale->artist->payoutMethod->account_holder,
+                        'clabe' => $sale->artist->payoutMethod->clabe,
+                        'rfc' => $sale->artist->payoutMethod->rfc,
+                    ] : null 
+                ]
+            ];
+        });
+
+        return response()->json([
+            'success' => true,
+            'data' => $formattedPayouts
+        ], 200);
+    }
+
+    public function releasePayout(int $saleId): JsonResponse
+    {   
+        $sale = ArtistSale::find($saleId);
+        if (!$sale) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No se encontró el registro de la venta.'
+            ], 404);
+        }
+
+        if ($sale->event_status !== 'completed') {
+            return response()->json([
+                'success' => false,
+                'message' => 'El evento físico aún no ha sido marcado como completado.'
+            ], 400);
+        }
+
+        if ($sale->status === 'liquidated') {
+            return response()->json([
+                'success' => false,
+                'message' => 'Esta liquidación ya fue pagada anteriormente.'
+            ], 400);
+        }
+        $sale->status = 'liquidated';
+        $sale->save();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'La liquidación ha sido marcada como pagada con éxito.'
+        ], 200);
+    }
+}

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -75,6 +75,6 @@ class Artist extends Model
 
     public function payoutMethod()
     {
-        return $this->hasOne(ArtistPayoutMethod::class);
+        return $this->hasOne(ArtistPayoutMethod::class, 'artist_id');
     }
 }

--- a/app/Models/ArtistSale.php
+++ b/app/Models/ArtistSale.php
@@ -11,6 +11,7 @@ class ArtistSale extends Model
         'artist_id',
         'customer_id',
         'amount',
+        'openpay_fee',
         'customer_first_name',
         'customer_last_name',
         'customer_email',

--- a/database/migrations/2026_06_23_134550_add_openpay_fee_to_artist_sales_table.php
+++ b/database/migrations/2026_06_23_134550_add_openpay_fee_to_artist_sales_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddOpenpayFeeToArtistSalesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('artist_sales', function (Blueprint $table) {
+            $table->decimal('openpay_fee', 8, 2)->default(0.00)->after('amount');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('artist_sales', function (Blueprint $table) {
+            $table->dropColumn('openpay_fee');
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,6 +30,7 @@ use App\Http\Controllers\Admin\OpenpayKeysController;
 use App\Http\Controllers\GoogleMapsController;
 use App\Http\Controllers\SupportTicketController;
 use App\Http\Controllers\ArtistPayoutMethodController;
+use App\Http\Controllers\Admin\AdminPayoutController;
 
 // Routes for login without sesion
 Route::post('/login', [AuthController::class, 'login']);
@@ -58,6 +59,8 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::resource('/admin/permissions', PermissionsApiController::class);
     Route::resource('/admin/musical-genders', MusicalsGendersController::class);
     Route::get('/admin/dashboard-overview', [DashboardStatsController::class, 'index']);
+    Route::get('/admin/payouts/pending', [AdminPayoutController::class, 'pendingPayouts']);
+    Route::post('/admin/payouts/{saleId}/release', [AdminPayoutController::class, 'releasePayout']);
 
     //Route for artist
     Route::post('/artist-new/up-date/{id}', [ArtistController::class, 'updateDetails']);


### PR DESCRIPTION
## Description
This PR introduces the complete backend implementation for the Admin Payouts (Liquidaciones) module. It provides the necessary endpoints to track, calculate, and process payments due to artists after successful event completions, ensuring proper platform fee deduction and security constraints.

### Key Features Included:
- **Payout Retrieval Endpoint:** Created `pendingPayouts` inside `AdminPayoutController` to fetch and aggregate active platform sales requiring settlement.
- **Financial Breakdown Logic:** Implemented dynamic backend calculations for every transaction:
  - Total customer payment distribution.
  - OpenPay gateway transaction fee deduction.
  - Platform commission withholding (10%).
  - Maximum safe calculation for the net artist payout (`net_artist_payout`).
- **State Machine Safeguards:** Developed the `releasePayout` endpoint to handle secure manual transfers. It includes data integrity checks to prevent double-spending by transitioning settled balances to a final `liquidated` status.
- **Data Relations:** Mapped multi-table database relationships linking `ArtistSale`, `Artist`, and `ArtistPayoutMethod` to safely expose bank details (CLABE, RFC, and Account Holder names).

---

### 🧠 Architectural Note for Reviewers
The system operates independently of chronological server time. Payout availability relies strictly on transaction lifecycle flags (`status = 'completed'` and `event_status = 'completed'`). This design enables seamless decoupling, allowing administration audits and state overrides in sandbox environments for manual QA verification without affecting production rules.