### PR TITLE
Segment artist sales patterns per customer with explicit timestamps

### DIFF
--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\ArtistSale;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
@@ -13,44 +14,39 @@ class ArtistSalesSeeder extends Seeder
     {
         DB::statement('TRUNCATE TABLE artist_sales RESTART IDENTITY CASCADE;');
 
-        $artistIds   = DB::table('artists')->orderBy('id')->pluck('id')->all();
-        $customerIds = [17, 18];
-        $customers   = User::whereIn('id', $customerIds)->get()->keyBy('id');
-        $eventHours  = ['08:00', '10:00', '14:00', '16:00', '18:00', '20:00'];
-        $amounts     = [6000, 9000, 12000];
+        $artistIds = DB::table('artists')->orderBy('id')->pluck('id')->all();
+        $customers = User::whereHas('roles', function ($q) {
+            $q->where('roles.id', 3);
+        })->get()->values();
 
-        $half = (int) ceil(count($artistIds) / 2);
-        $artistsPerCustomer = [
-            17 => array_slice($artistIds, 0, $half),
-            18 => array_slice($artistIds, $half),
+        $eventHours = ['08:00', '10:00', '14:00', '16:00', '18:00', '20:00'];
+        $amounts    = [6000, 9000, 12000];
+
+        $eventDateOffsets = [-90, -60, -30, -15, 15, 30, 60, 90, 120, 150];
+        $createdAtOffsets = [-150, -120, -90, -75, -60, -30, -20, -10];
+        $paymentMethods    = ['card', 'cash'];
+
+        $salesPattern = [
+            ['status' => 'completed', 'event_status' => 'completed'],
+            ['status' => 'pending',   'event_status' => 'pending'],
+            ['status' => 'pending',   'event_status' => 'pending'],
         ];
 
-        $patternsPerCustomer = [
-            17 => [
-                ['event_date' => '2026-03-10', 'created_at' => '2026-01-15 10:00:00', 'payment_method' => 'card',  'status' => 'completed', 'event_status' => 'completed'],
-                ['event_date' => '2026-08-20', 'created_at' => '2026-06-01 10:00:00', 'payment_method' => 'cash',  'status' => 'pending',   'event_status' => 'pending'],
-                ['event_date' => '2026-10-05', 'created_at' => '2026-06-10 10:00:00', 'payment_method' => 'card',  'status' => 'completed', 'event_status' => 'pending'],
-            ],
-            18 => [
-                ['event_date' => '2026-04-15', 'created_at' => '2026-02-20 10:00:00', 'payment_method' => 'cash',  'status' => 'pending',   'event_status' => 'completed'],
-                ['event_date' => '2026-09-10', 'created_at' => '2026-05-05 10:00:00', 'payment_method' => 'card',  'status' => 'completed', 'event_status' => 'pending'],
-                ['event_date' => '2026-11-20', 'created_at' => '2026-06-20 10:00:00', 'payment_method' => 'cash',  'status' => 'pending',   'event_status' => 'pending'],
-            ],
-        ];
+        for ($i = 0; $i < count($artistIds); $i++) {
+            $artistId = $artistIds[$i];
 
-        foreach ($customerIds as $customerId) {
-            $customer = $customers[$customerId];
-            $artists  = $artistsPerCustomer[$customerId];
-            $patterns = $patternsPerCustomer[$customerId];
+            for ($j = 0; $j < count($salesPattern); $j++) {
+                $customer      = $customers[array_rand($customers->all())];
+                $statusPattern = $salesPattern[$j];
 
-            foreach ($artists as $index => $artistId) {
-                $pattern = $patterns[$index % count($patterns)];
+                $eventDate = Carbon::now()->addDays($eventDateOffsets[array_rand($eventDateOffsets)])->format('Y-m-d');
+                $createdAt = Carbon::now()->addDays($createdAtOffsets[array_rand($createdAtOffsets)])->format('Y-m-d H:i:s');
 
                 ArtistSale::create([
                     'artist_id'              => $artistId,
-                    'customer_id'            => $customerId,
-                    'amount'                 => $amounts[$index % count($amounts)],
-                    'openpay_transaction_id' => 'trx_test_' . $artistId . '_' . $customerId,
+                    'customer_id'            => $customer->id,
+                    'amount'                 => $amounts[array_rand($amounts)],
+                    'openpay_transaction_id' => 'trx_test_' . $artistId . '_' . $customer->id . '_' . $j,
                     'customer_first_name'    => explode(' ', $customer->name)[0],
                     'customer_last_name'     => explode(' ', $customer->name)[1] ?? 'Usuario',
                     'customer_email'         => $customer->email,
@@ -59,14 +55,14 @@ class ArtistSalesSeeder extends Seeder
                     'customer_city'          => 'Ciudad de México',
                     'customer_state'         => 'CDMX',
                     'customer_zip_code'      => '28001',
-                    'event_date'             => $pattern['event_date'],
-                    'event_hour'             => $eventHours[$index % count($eventHours)],
+                    'event_date'             => $eventDate,
+                    'event_hour'             => $eventHours[array_rand($eventHours)],
                     'event_hours'            => rand(2, 5),
-                    'payment_method'         => $pattern['payment_method'],
-                    'event_status'           => $pattern['event_status'],
-                    'status'                 => $pattern['status'],
-                    'created_at'             => $pattern['created_at'],
-                    'updated_at'             => $pattern['created_at'],
+                    'payment_method'         => $paymentMethods[array_rand($paymentMethods)],
+                    'event_status'           => $statusPattern['event_status'],
+                    'status'                 => $statusPattern['status'],
+                    'created_at'             => $createdAt,
+                    'updated_at'             => $createdAt,
                 ]);
             }
         }

--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -16,7 +16,7 @@ class ArtistSalesSeeder extends Seeder
 
         $artistIds = DB::table('artists')->orderBy('id')->pluck('id')->all();
         $customers = User::whereHas('roles', function ($q) {
-            $q->where('roles.id', 3);
+            $q->where('slug', User::ROLE_CLIENT);
         })->get()->values();
 
         $eventHours = ['08:00', '10:00', '14:00', '16:00', '18:00', '20:00'];

--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -19,17 +19,31 @@ class ArtistSalesSeeder extends Seeder
         $eventHours  = ['08:00', '10:00', '14:00', '16:00', '18:00', '20:00'];
         $amounts     = [6000, 9000, 12000];
 
-        $patterns = [
-            ['event_date' => '2026-04-20', 'payment_method' => 'cash',  'status' => 'pending'],
-            ['event_date' => '2026-05-10', 'payment_method' => 'card',  'status' => 'completed'],
-            ['event_date' => '2026-08-20', 'payment_method' => 'cash',  'status' => 'pending'],
-            ['event_date' => '2026-09-15', 'payment_method' => 'card',  'status' => 'completed'],
+        $half = (int) ceil(count($artistIds) / 2);
+        $artistsPerCustomer = [
+            17 => array_slice($artistIds, 0, $half),
+            18 => array_slice($artistIds, $half),
         ];
 
-        foreach ($customerIds as $customerIndex => $customerId) {
-            $customer = $customers[$customerId];
+        $patternsPerCustomer = [
+            17 => [
+                ['event_date' => '2026-03-10', 'created_at' => '2026-01-15 10:00:00', 'payment_method' => 'card',  'status' => 'completed', 'event_status' => 'completed'],
+                ['event_date' => '2026-08-20', 'created_at' => '2026-06-01 10:00:00', 'payment_method' => 'cash',  'status' => 'pending',   'event_status' => 'pending'],
+                ['event_date' => '2026-10-05', 'created_at' => '2026-06-10 10:00:00', 'payment_method' => 'card',  'status' => 'completed', 'event_status' => 'pending'],
+            ],
+            18 => [
+                ['event_date' => '2026-04-15', 'created_at' => '2026-02-20 10:00:00', 'payment_method' => 'cash',  'status' => 'pending',   'event_status' => 'completed'],
+                ['event_date' => '2026-09-10', 'created_at' => '2026-05-05 10:00:00', 'payment_method' => 'card',  'status' => 'completed', 'event_status' => 'pending'],
+                ['event_date' => '2026-11-20', 'created_at' => '2026-06-20 10:00:00', 'payment_method' => 'cash',  'status' => 'pending',   'event_status' => 'pending'],
+            ],
+        ];
 
-            foreach ($artistIds as $index => $artistId) {
+        foreach ($customerIds as $customerId) {
+            $customer = $customers[$customerId];
+            $artists  = $artistsPerCustomer[$customerId];
+            $patterns = $patternsPerCustomer[$customerId];
+
+            foreach ($artists as $index => $artistId) {
                 $pattern = $patterns[$index % count($patterns)];
 
                 ArtistSale::create([
@@ -49,8 +63,10 @@ class ArtistSalesSeeder extends Seeder
                     'event_hour'             => $eventHours[$index % count($eventHours)],
                     'event_hours'            => rand(2, 5),
                     'payment_method'         => $pattern['payment_method'],
-                    'event_status'           => 'pending',
+                    'event_status'           => $pattern['event_status'],
                     'status'                 => $pattern['status'],
+                    'created_at'             => $pattern['created_at'],
+                    'updated_at'             => $pattern['created_at'],
                 ]);
             }
         }


### PR DESCRIPTION
## Description
Refactored `ArtistSalesSeeder` to segment dummy data creation based on specific customers (IDs 17 and 18). Each profile now maps to bounded array slices of artists and sequential deterministic date configurations for payments and events.

## Why
The previous seeding strategy assigned unified global date sequences across all generated items, causing test cases for sales reports and order history timelines to overlap unrealistically. Distinct buyer behavior and exact `created_at` timestamps were required to test frontend purchase filters and timeline sorting mechanisms accurately.

## Impact
- **Data Quality:** Generates data structures reflecting historical transactional flow rather than bulk creation anomalies.
- **Testing Reliability:** Provides explicit edge cases matching status variances (`pending` / `completed` statuses on events vs payments).

## Changes
- **database/seeders/ArtistSalesSeeder.php**:
  - Replaced universal `$patterns` with customer-keyed `$patternsPerCustomer` matrix.
  - Implemented `array_slice` to divide `$artistIds` evenly into unique subsets (`$artistsPerCustomer`).
  - Added explicit values for `created_at` and `updated_at` records to populate historical transaction tables.

## Testing Plan
1. **Seeder execution:** Run `php artisan db:seed --class=ArtistSalesSeeder` and ensure execution concludes without validation failures.
2. **Database Verification:** Verify in `artist_sales` table that records belonging to customers 17 and 18 conform precisely to the mapped dates and status configurations.