### PR TITLE
Feature: Add image support to musical genders and improve genre card design

### DIFF
--- a/app/Http/Controllers/Admin/MusicalsGendersController.php
+++ b/app/Http/Controllers/Admin/MusicalsGendersController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Storage;
 
 class MusicalsGendersController extends Controller
 {
@@ -56,6 +57,7 @@ class MusicalsGendersController extends Controller
             'name' => 'required|string|max:255|unique:musical_genders,name',
             'description' => 'required|string|min:10',
             'color' => 'required|string',
+            'image' => 'nullable|file|mimes:jpg,jpeg,png,gif,webp,bmp|max:20480',
         ], [
             'name.unique' => 'El género musical ya se encuentra registrado.',
             'name.required' => 'El nombre del género es obligatorio.',
@@ -77,6 +79,12 @@ class MusicalsGendersController extends Controller
             $musicalGenders->slug = $slug;
             $musicalGenders->description = $request->input('description');
             $musicalGenders->color = $request->input('color');
+
+            if ($request->hasFile('image')) {
+                $urlStore = Storage::put('public/musical-genders', $request->file('image'));
+                $musicalGenders->image = url(Storage::url($urlStore));
+            }
+
             $musicalGenders->save();
 
             DB::commit();
@@ -130,6 +138,7 @@ class MusicalsGendersController extends Controller
             'name' => 'required|string|max:255|unique:musical_genders,name,' . $id,
             'description' => 'required|string|min:10',
             'color' => 'required|string',
+            'image' => 'nullable|file|mimes:jpg,jpeg,png,gif,webp,bmp|max:20480',
         ], [
             'name.unique' => 'El género musical ya se encuentra registrado.',
             'name.required' => 'El nombre del género es obligatorio.',
@@ -150,6 +159,18 @@ class MusicalsGendersController extends Controller
             $musicalGenders->slug = $slug;
             $musicalGenders->description = $request->input('description');
             $musicalGenders->color = $request->input('color');
+
+            if ($request->hasFile('image')) {
+                if ($musicalGenders->image) {
+                    $oldPath = str_replace(url('storage'), 'public', $musicalGenders->image);
+                    $less = env('APP_URL') . '/public/';
+                    $oldPath = str_replace($less, '', $oldPath);
+                    Storage::delete($oldPath);
+                }
+                $urlStore = Storage::put('public/musical-genders', $request->file('image'));
+                $musicalGenders->image = url(Storage::url($urlStore));
+            }
+
             $musicalGenders->save();
             DB::commit();
 

--- a/app/Models/MusicalGender.php
+++ b/app/Models/MusicalGender.php
@@ -13,6 +13,8 @@ class MusicalGender extends Model
         'name',
         'slug',
         'description',
+        'color',
+        'image',
     ];
 
     public function artists()

--- a/database/migrations/2026_06_25_102128_add_image_to_musical_genders_table.php
+++ b/database/migrations/2026_06_25_102128_add_image_to_musical_genders_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
@@ -15,8 +16,6 @@ return new class extends Migration
 
     public function down()
     {
-        Schema::table('musical_genders', function (Blueprint $table) {
-            $table->dropColumn('image');
-        });
+        DB::statement('ALTER TABLE musical_genders DROP COLUMN image CASCADE');
     }
 };

--- a/database/migrations/2026_06_25_102128_add_image_to_musical_genders_table.php
+++ b/database/migrations/2026_06_25_102128_add_image_to_musical_genders_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('musical_genders', function (Blueprint $table) {
+            $table->string('image')->nullable()->after('color');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('musical_genders', function (Blueprint $table) {
+            $table->dropColumn('image');
+        });
+    }
+};


### PR DESCRIPTION
**Summary**

This PR enhances the musical genres module by allowing administrators to upload an image for each musical genre.

Additionally, the client-facing genre cards were redesigned to provide a more attractive and informative presentation, improving the browsing experience when exploring available musical genres.

**Changes Implemented**

🔹 Musical Genre Images

- Added image upload support to the musical genre form.
- Allows administrators to associate an image with each genre.
- Extended the musical genres data model to store image information.
- Updated backend logic to process and persist uploaded images.

🔹 Genre Card Redesign

- Improved the visual design of musical genre cards.
- Enhanced presentation of genre information.
- Improved responsiveness and user experience.
- Added support for displaying uploaded genre images.

🔹 Administration Improvements

- Updated genre management forms to handle image uploads.
- Improved genre creation and editing workflows.
- Added support for image persistence during updates.

🔹 Client Experience Improvements

- Enhanced browsing experience for musical genres.
- Improved visual identification of genres.
- Increased engagement through richer content presentation.

**📁 Files Modified**

Backend

Controllers

- app/Http/Controllers/Admin/MusicalsGendersController.php

Models

- app/Models/MusicalGender.php

Migrations

- database/migrations/2026_06_25_102128_add_image_to_musical_genders_table.php