### PR TITLE
Feature/integrate openpay fee calculation

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -28,7 +28,7 @@ use App\Services\DistanceMatrixService;
 class PaymentController extends Controller
 {
 
-    public function processPayment(Request $request)
+   public function processPayment(Request $request)
     {
         $acquiredLocks = [];
 
@@ -235,6 +235,7 @@ class PaymentController extends Controller
                     $sale->artist_id = $item['artist_id'];
                     $sale->customer_id = $userId;
                     $sale->amount = $item['amount'];
+                    $sale->openpay_fee = $this->resolveOpenpayFee($charge, (float) $item['amount']);
                     $sale->customer_first_name = $name;
                     $sale->customer_last_name = $last_name;
                     $sale->customer_email = $email;
@@ -1070,5 +1071,18 @@ class PaymentController extends Controller
             'message' => 'Pago confirmado correctamente',
             'updated' => 1,
         ]);
+    }
+
+    private function resolveOpenpayFee($charge, float $amount): float
+    {
+        if (isset($charge->fee) && is_object($charge->fee) && isset($charge->fee->amount)) {
+            return (float) $charge->fee->amount;
+        }
+
+        $baseCommissionRate = 0.029;
+        $fixedCharge = 2.50;
+        $taxRate = 1.16;
+
+        return round((($amount * $baseCommissionRate) + $fixedCharge) * $taxRate, 2);
     }
 }

--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -31,11 +31,18 @@ class ArtistSalesSeeder extends Seeder
 
             foreach ($artistIds as $index => $artistId) {
                 $pattern = $patterns[$index % count($patterns)];
+                
+                $amount = $amounts[$index % count($amounts)];
+                
+                $openpayFee = ($pattern['payment_method'] === 'card') 
+                    ? round(($amount * 0.029) * 1.16, 2) 
+                    : 0.00;
 
                 ArtistSale::create([
                     'artist_id'              => $artistId,
                     'customer_id'            => $customerId,
-                    'amount'                 => $amounts[$index % count($amounts)],
+                    'amount'                 => $amount,
+                    'openpay_fee'            => $openpayFee,
                     'openpay_transaction_id' => 'trx_test_' . $artistId . '_' . $customerId,
                     'customer_first_name'    => explode(' ', $customer->name)[0],
                     'customer_last_name'     => explode(' ', $customer->name)[1] ?? 'Usuario',

--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -19,12 +19,11 @@ class ArtistSalesSeeder extends Seeder
             $q->where('slug', User::ROLE_CLIENT);
         })->get()->values();
 
-        $eventHours = ['08:00', '10:00', '14:00', '16:00', '18:00', '20:00'];
-        $amounts    = [6000, 9000, 12000];
-
+        $eventHours     = ['08:00', '10:00', '14:00', '16:00', '18:00', '20:00'];
+        $amounts        = [6000, 9000, 12000];
         $eventDateOffsets = [-90, -60, -30, -15, 15, 30, 60, 90, 120, 150];
         $createdAtOffsets = [-150, -120, -90, -75, -60, -30, -20, -10];
-        $paymentMethods    = ['card', 'cash'];
+        $paymentMethods   = ['card', 'cash'];
 
         $salesPattern = [
             ['status' => 'completed', 'event_status' => 'completed'],
@@ -38,29 +37,22 @@ class ArtistSalesSeeder extends Seeder
             for ($j = 0; $j < count($salesPattern); $j++) {
                 $customer      = $customers[array_rand($customers->all())];
                 $statusPattern = $salesPattern[$j];
-
-            foreach ($artistIds as $index => $artistId) {
-                $pattern = $patterns[$index % count($patterns)];
                 
-                $amount = $amounts[$index % count($amounts)];
+                $paymentMethod = $paymentMethods[array_rand($paymentMethods)];
                 
-                $openpayFee = ($pattern['payment_method'] === 'card') 
+                $amount = $amounts[array_rand($amounts)];
+                $openpayFee = ($paymentMethod === 'card') 
                     ? round(($amount * 0.029) * 1.16, 2) 
                     : 0.00;
 
-                ArtistSale::create([
-                    'artist_id'              => $artistId,
-                    'customer_id'            => $customerId,
-                    'amount'                 => $amount,
-                    'openpay_fee'            => $openpayFee,
-                    'openpay_transaction_id' => 'trx_test_' . $artistId . '_' . $customerId,
                 $eventDate = Carbon::now()->addDays($eventDateOffsets[array_rand($eventDateOffsets)])->format('Y-m-d');
                 $createdAt = Carbon::now()->addDays($createdAtOffsets[array_rand($createdAtOffsets)])->format('Y-m-d H:i:s');
 
                 ArtistSale::create([
                     'artist_id'              => $artistId,
                     'customer_id'            => $customer->id,
-                    'amount'                 => $amounts[array_rand($amounts)],
+                    'amount'                 => $amount,
+                    'openpay_fee'            => $openpayFee,
                     'openpay_transaction_id' => 'trx_test_' . $artistId . '_' . $customer->id . '_' . $j,
                     'customer_first_name'    => explode(' ', $customer->name)[0],
                     'customer_last_name'     => explode(' ', $customer->name)[1] ?? 'Usuario',
@@ -73,7 +65,7 @@ class ArtistSalesSeeder extends Seeder
                     'event_date'             => $eventDate,
                     'event_hour'             => $eventHours[array_rand($eventHours)],
                     'event_hours'            => rand(2, 5),
-                    'payment_method'         => $paymentMethods[array_rand($paymentMethods)],
+                    'payment_method'         => $paymentMethod,
                     'event_status'           => $statusPattern['event_status'],
                     'status'                 => $statusPattern['status'],
                     'created_at'             => $createdAt,


### PR DESCRIPTION
## Description
This PR addresses the missing OpenPay fee data in the artist sales records. It introduces a clean approach to resolve transaction fees from the OpenPay SDK response while providing a fallback mathematical calculation for local testing environments. Additionally, the database seeder was updated to ensure test data accurately reflects these financial metrics based on the selected payment method.

## Changes Made
- Added `resolveOpenpayFee` private method in `PaymentController.php` to handle SDK object mapping and mock data fallback.
- Updated the checkout loop in `PaymentController.php` to assign the resolved fee to each sale record.
- Fixed `ArtistSalesSeeder.php` to dynamically compute and populate the `openpay_fee` column for card transaction patterns instead of defaulting to 0.00.