### PR TITLE
Feature: Add support ticket history for clients and artists

### DIFF
--- a/app/Http/Controllers/SupportTicketController.php
+++ b/app/Http/Controllers/SupportTicketController.php
@@ -141,4 +141,15 @@ class SupportTicketController extends Controller
             'data' => $ticket->logs()->get()
         ]);
     }
+
+    public function myTicketLogs(SupportTicket $ticket)
+    {
+        if ($ticket->reporter_user_id !== Auth::id()) {
+            return response()->json(['message' => 'No autorizado'], 403);
+        }
+
+        return response()->json([
+            'data' => $ticket->logs()->get()
+        ]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -141,6 +141,7 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::post('/support-tickets', [SupportTicketController::class, 'store']);
     Route::post('/support-tickets/{ticket}/evidences', [SupportTicketController::class, 'uploadEvidence']);
     Route::get('/support-tickets/my', [SupportTicketController::class, 'myTickets']);
+    Route::get('/support-tickets/{ticket}/logs', [SupportTicketController::class, 'myTicketLogs']);
     Route::get('/admin/support-tickets', [SupportTicketController::class, 'index']);
     Route::get('/admin/support-tickets/{ticket}', [SupportTicketController::class, 'show']);
     Route::patch('/admin/support-tickets/{ticket}/status', [SupportTicketController::class, 'updateStatus']);


### PR DESCRIPTION
**Summary**

This PR introduces a ticket history feature that allows both clients and artists to view the activity log of their support tickets.

The implementation provides greater visibility into ticket progress by displaying historical updates and status changes, improving communication and transparency throughout the support process.

**📁 Files Modified**

Backend

Controllers

- app/Http/Controllers/SupportTicketController.php

Routes

- routes/api.php