### PR TITLE
Implement two-step reservation approval flow with openpay pre-authorization

### DIFF
--- a/app/Console/Commands/ExpireApprovalRequests.php
+++ b/app/Console/Commands/ExpireApprovalRequests.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\ArtistSale;
+use App\Models\OpenpayKey;
+use Carbon\Carbon;
+use Openpay\Data\Openpay;
+use Illuminate\Support\Facades\Log;
+
+class ExpireApprovalRequests extends Command
+{
+    protected $signature = 'approvals:expire';
+    protected $description = 'Expira solicitudes de aprobación de artista que llevan más de 24h sin respuesta';
+
+    public function handle()
+    {
+        $expired = ArtistSale::where('approval_status', 'pending_approval')
+            ->whereNotNull('approval_deadline')
+            ->where('approval_deadline', '<', Carbon::now())
+            ->get();
+
+        $keys = OpenpayKey::first();
+        $openpay = Openpay::getInstance($keys->openpay_id, $keys->openpay_secret, 'MX');
+        Openpay::setProductionMode(false);
+
+        $count = 0;
+        foreach ($expired as $sale) {
+            if ($sale->payment_method === 'card' && $sale->openpay_transaction_id) {
+                try {
+                    $charge = $openpay->charges->get($sale->openpay_transaction_id);
+                    $charge->refund(['description' => 'Solicitud expirada sin respuesta del artista']);
+                } catch (\Exception $e) {
+                    Log::warning("No se pudo cancelar autorización OpenPay para sale {$sale->id}: " . $e->getMessage());
+                }
+            }
+
+            $sale->approval_status = 'expired';
+            $sale->event_status = 'expired';
+            $sale->save();
+            $count++;
+        }
+
+        $this->info("Solicitudes expiradas: {$count}");
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,7 +16,6 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         // $schedule->command('inspire')->hourly();
-        $schedule->command('approvals:expire')->hourly();
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         // $schedule->command('inspire')->hourly();
+        $schedule->command('approvals:expire')->hourly();
     }
 
     /**

--- a/app/Http/Controllers/Artist/ApprovalController.php
+++ b/app/Http/Controllers/Artist/ApprovalController.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Http\Controllers\Artist;
+
+use App\Http\Controllers\Controller;
+use App\Models\ArtistSale;
+use App\Models\Artist;
+use App\Models\OpenpayKey;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Carbon\Carbon;
+use Openpay\Data\Openpay;
+
+class ApprovalController extends Controller
+{
+    public function pendingRequests()
+    {
+        try {
+            $user = Auth::user();
+            $artist = Artist::where('user_id', $user->id)->first();
+
+            if (!$artist) {
+                return response()->json(['success' => false, 'message' => 'Perfil de artista no encontrado'], 404);
+            }
+
+            $pending = ArtistSale::where('artist_id', $artist->id)
+                ->where('approval_status', 'pending_approval')
+                ->whereNotNull('approval_deadline')
+                ->where('approval_deadline', '>', Carbon::now())
+                ->with('customer')
+                ->oldest()
+                ->get()
+                ->map(function ($sale) {
+                    $sale->time_remaining_seconds = Carbon::now()->diffInSeconds(
+                        Carbon::parse($sale->approval_deadline),
+                        false
+                    );
+                    return $sale;
+                });
+
+            return response()->json(['success' => true, 'sales' => $pending]);
+        } catch (\Exception $e) {
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
+    }
+
+    public function accept($id)
+    {
+        try {
+            $user = Auth::user();
+            $artist = Artist::where('user_id', $user->id)->first();
+
+            if (!$artist) {
+                return response()->json(['success' => false, 'message' => 'Perfil de artista no encontrado'], 404);
+            }
+
+            $sale = ArtistSale::where('id', $id)
+                ->where('artist_id', $artist->id)
+                ->where('approval_status', 'pending_approval')
+                ->first();
+
+            if (!$sale) {
+                return response()->json(['success' => false, 'message' => 'Solicitud no encontrada o ya fue respondida'], 404);
+            }
+
+            if (Carbon::now()->gt(Carbon::parse($sale->approval_deadline))) {
+                $sale->approval_status = 'expired';
+                $sale->save();
+                return response()->json(['success' => false, 'message' => 'El tiempo para responder ha expirado'], 422);
+            }
+
+            $keys = OpenpayKey::first();
+            $openpay = Openpay::getInstance($keys->openpay_id, $keys->openpay_secret, 'MX');
+            Openpay::setProductionMode(false);
+
+            if ($sale->payment_method === 'card' && $sale->openpay_transaction_id) {
+                $charge = $openpay->charges->get($sale->openpay_transaction_id);
+                $charge->capture([
+                    'amount' => (float) $sale->amount,
+                ]);
+            }
+
+            if ($sale->payment_method === 'cash') {
+                $customerData = [
+                    'name'             => $sale->customer_first_name,
+                    'last_name'        => $sale->customer_last_name,
+                    'email'            => $sale->customer_email,
+                    'requires_account' => false,
+                    'address'          => [
+                        'line1'        => $sale->customer_address ?? 'Sin dirección',
+                        'city'         => $sale->customer_city ?? 'Ciudad',
+                        'state'        => $sale->customer_state ?? 'Estado',
+                        'postal_code'  => $sale->customer_zip_code ?? '00000',
+                        'country_code' => 'MX',
+                    ],
+                ];
+
+                $chargeRequest = [
+                    'method'      => 'store',
+                    'amount'      => (float) $sale->amount,
+                    'currency'    => 'MXN',
+                    'description' => 'Reserva artista - Pago en efectivo',
+                    'customer'    => $customerData,
+                    'due_date'    => Carbon::now()->addHours(24)->format('Y-m-d\TH:i:s'),
+                ];
+
+                $charge = $openpay->charges->create($chargeRequest);
+                $sale->openpay_transaction_id = $charge->id;
+            }
+
+            $sale->status = $sale->payment_method === 'card' ? 'completed' : 'pending';
+            $sale->approval_status = 'accepted';
+            $sale->approval_responded_at = Carbon::now();
+            $sale->save();
+
+            return response()->json(['success' => true, 'message' => 'Solicitud aceptada correctamente', 'sale' => $sale]);
+        } catch (\Exception $e) {
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
+    }
+
+    public function reject($id)
+    {
+        try {
+            $user = Auth::user();
+            $artist = Artist::where('user_id', $user->id)->first();
+
+            if (!$artist) {
+                return response()->json(['success' => false, 'message' => 'Perfil de artista no encontrado'], 404);
+            }
+
+            $sale = ArtistSale::where('id', $id)
+                ->where('artist_id', $artist->id)
+                ->where('approval_status', 'pending_approval')
+                ->first();
+
+            if (!$sale) {
+                return response()->json(['success' => false, 'message' => 'Solicitud no encontrada o ya fue respondida'], 404);
+            }
+
+            if ($sale->payment_method === 'card' && $sale->openpay_transaction_id) {
+                try {
+                    $keys = OpenpayKey::first();
+                    $openpay = Openpay::getInstance($keys->openpay_id, $keys->openpay_secret, 'MX');
+                    Openpay::setProductionMode(false);
+                    $charge = $openpay->charges->get($sale->openpay_transaction_id);
+                    $charge->refund(['description' => 'Artista rechazó la solicitud']);
+                } catch (\Exception $e) {
+                    \Illuminate\Support\Facades\Log::warning('No se pudo cancelar la autorización OpenPay: ' . $e->getMessage());
+                }
+            }
+            
+            $sale->status = 'cancelled';
+            $sale->approval_status = 'rejected';
+            $sale->approval_responded_at = Carbon::now();
+            $sale->event_status = 'expired';
+            $sale->save();
+
+            return response()->json(['success' => true, 'message' => 'Solicitud rechazada']);
+        } catch (\Exception $e) {
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/Artist/ApprovalController.php
+++ b/app/Http/Controllers/Artist/ApprovalController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
 use Openpay\Data\Openpay;
+use Illuminate\Support\Facades\Log;
 
 class ApprovalController extends Controller
 {
@@ -146,7 +147,7 @@ class ApprovalController extends Controller
                     $charge = $openpay->charges->get($sale->openpay_transaction_id);
                     $charge->refund(['description' => 'Artista rechazó la solicitud']);
                 } catch (\Exception $e) {
-                    \Illuminate\Support\Facades\Log::warning('No se pudo cancelar la autorización OpenPay: ' . $e->getMessage());
+                    Log::warning('No se pudo cancelar la autorización OpenPay: ' . $e->getMessage());
                 }
             }
             

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -216,6 +216,7 @@ class PaymentController extends Controller
                     'amount' => $amount,
                     'currency' => 'MXN',
                     'description' => 'Cargo de reserva de artista',
+                    'capture' => false,
                     'customer' => $customerData,
                     'redirect_url' => 'http://www.openpay.mx/index.html'
                 );
@@ -248,13 +249,16 @@ class PaymentController extends Controller
                     $sale->event_hour = $item['event_hour'];
                     $sale->event_hours = $item['hours'] ?? null;
                     $sale->event_status = 'pending';
-                    $sale->status = 'completed';
+                    $sale->status = 'authorized';
                     $sale->payment_method = 'card';
                     $sale->latitude = $latitude;
                     $sale->longitude = $longitude;
                     $sale->google_place_id = $googlePlaceId;
                     $sale->extra_km_distance = $item['extra_km_distance'];
                     $sale->extra_km_cost = $item['extra_km_cost'];
+                    $sale->approval_status = 'pending_approval';
+                    $sale->approval_deadline = Carbon::now()->addHours(24);
+                    $sale->openpay_customer_id = $charge->customer->id ?? null;
                     $sale->save();
                 }
 
@@ -662,11 +666,6 @@ class PaymentController extends Controller
     public function processCashPayment(Request $request)
     {
         try {
-            $keys = OpenpayKey::first();
-            $openpay = Openpay::getInstance($keys->openpay_id, $keys->openpay_secret, "MX");
-            Openpay::setProductionMode(false);
-
-            $dueDateInstance = Carbon::now()->addHours(24);
 
             $name        = $request->input('order_details.first_name') ?? $request->input('customer_name');
             $last_name   = $request->input('order_details.last_name', '');
@@ -802,36 +801,11 @@ class PaymentController extends Controller
                 }
             }
 
-            $customerData = [
-                'name'             => $name,
-                'last_name'        => $last_name,
-                'email'            => $email,
-                'requires_account' => false,
-                'address'          => [
-                    'line1'        => $address,
-                    'state'        => $state,
-                    'city'         => $city,
-                    'postal_code'  => $zip_code,
-                    'country_code' => 'MX',
-                ],
-            ];
-
-            $chargeRequest = [
-                'method'      => 'store',
-                'amount'      => $amount,
-                'currency'    => 'MXN',
-                'description' => 'Reserva artista - Pago en efectivo (' . $store . ')',
-                'customer'    => $customerData,
-                'due_date'    => Carbon::now()->addHours(24)->format('Y-m-d\TH:i:s'),
-            ];
-
-            $charge = $openpay->charges->create($chargeRequest);
 
             DB::beginTransaction();
             try {
                 foreach ($itemsForSales as $item) {
                     $sale = new ArtistSale();
-                    $sale->openpay_transaction_id = $charge->id;
                     $sale->status = 'pending';
                     $sale->event_status = 'pending';
                     $sale->artist_id              = $item['artist_id'];
@@ -854,6 +828,8 @@ class PaymentController extends Controller
                     $sale->google_place_id = $googlePlaceId;
                     $sale->extra_km_distance = $item['extra_km_distance'];
                     $sale->extra_km_cost = $item['extra_km_cost'];
+                    $sale->approval_status = 'pending_approval';
+                    $sale->approval_deadline = Carbon::now()->addHours(24);
                     $sale->save();
                 }
 
@@ -882,16 +858,7 @@ class PaymentController extends Controller
             }
 
             return response()->json([
-                'data'      => [
-                    'id'        => $charge->id,
-                    'amount'    => $charge->amount,
-                    'status'    => $charge->status,
-                    'store'     => $store,
-                    'reference' => $charge->payment_method->reference ?? null,
-                    'barcode'   => $charge->payment_method->barcode_url ?? null,
-                    'due_date'  => $dueDateInstance->toDateTimeString(),
-                ],
-                'message'   => 'Referencia de pago generada correctamente',
+                'message' => 'Reserva registrada correctamente. Pendiente de aprobación.',
             ]);
 
         } catch (OpenpayApiTransactionError $e) {

--- a/app/Models/ArtistSale.php
+++ b/app/Models/ArtistSale.php
@@ -32,6 +32,10 @@ class ArtistSale extends Model
         'google_place_id',
         'extra_km_distance',
         'extra_km_cost',
+        'approval_status',
+        'approval_deadline',
+        'approval_responded_at',
+        'openpay_customer_id',
     ];
 
     public function artist()

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Console\Scheduling\Schedule;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -23,6 +24,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->app->resolving(Schedule::class, function (Schedule $schedule) {
+            $schedule->command('approvals:expire')->hourly();
+        });
     }
 }

--- a/database/migrations/2026_06_29_000001_add_approval_fields_to_artist_sales_table.php
+++ b/database/migrations/2026_06_29_000001_add_approval_fields_to_artist_sales_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('artist_sales', function (Blueprint $table) {
+            $table->enum('approval_status', ['pending_approval', 'accepted', 'rejected', 'expired'])
+                ->default('accepted')
+                ->after('event_status');
+            $table->timestamp('approval_deadline')->nullable()->after('approval_status');
+            $table->timestamp('approval_responded_at')->nullable()->after('approval_deadline');
+            $table->string('openpay_customer_id')->nullable()->after('openpay_transaction_id');
+        });
+    }
+
+    public function down(): void
+    {
+        DB::statement('
+            ALTER TABLE artist_sales 
+            DROP COLUMN approval_status CASCADE,
+            DROP COLUMN approval_deadline CASCADE,
+            DROP COLUMN approval_responded_at CASCADE,
+            DROP COLUMN openpay_customer_id CASCADE
+        ');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,7 @@ use App\Http\Controllers\GoogleMapsController;
 use App\Http\Controllers\SupportTicketController;
 use App\Http\Controllers\ArtistPayoutMethodController;
 use App\Http\Controllers\Admin\AdminPayoutController;
+use App\Http\Controllers\Artist\ApprovalController;
 
 // Routes for login without sesion
 Route::post('/login', [AuthController::class, 'login']);
@@ -79,6 +80,9 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::get('/artist/payout-method', [ArtistPayoutMethodController::class, 'show']);
     Route::post('/artist/payout-method', [ArtistPayoutMethodController::class, 'store']);
     Route::put('/artist/payout-method', [ArtistPayoutMethodController::class, 'update']);
+    Route::get('/artist/approval/pending', [ApprovalController::class, 'pendingRequests']);
+    Route::put('/artist/approval/{id}/accept', [ApprovalController::class, 'accept']);
+    Route::put('/artist/approval/{id}/reject', [ApprovalController::class, 'reject']);
     //Route for client
     Route::resource('/client-card', ClientController::class);
     Route::get('/client/profile', [ClientController::class, 'getProfile']);


### PR DESCRIPTION
## 📝 Description
This PR introduces a two-step booking verification flow. Card payments are now processed as pre-authorizations (`'capture' => false`), moving status mapping from `completed` to `authorized`. Artists gain a 24-hour window to review, accept, or reject incoming gig requests via specific endpoints, backed by an automated hourly command to purge stale items.

## 🎯 Why
Direct captures caused heavy overhead when artists had sudden calendar conflicts or double-bookings, forcing immediate refunds and triggering high gateway processing fees. Pre-authorizing the hold allows the platform to secure funds temporarily without completing the transaction until the artist confirms availability.

## ⚡ Impact
- **Financial Safety:** Minimizes gateway chargebacks and redundant transactional fees from refunds.
- **Automation:** Guarantees automated platform hygiene by dropping un-actioned authorizations through an hourly cron schedule.

## 🛠️ Changes
- **`app/Http/Controllers/PaymentController.php`**: Dispatched card requests with `capture => false`, updated baseline flags to `authorized`, and refactored cash orders to await confirmation structures.
- **`database/migrations/*_add_approval_fields_to_artist_sales_table.php`**: Generated columns for tracking statuses (`approval_status`), response timestamps, and explicit Openpay references.
- **`app/Console/Commands/` & `Kernel.php`**: Established `approvals:expire` routine running on an hourly frequency.
- **`routes/api.php`**: Appended management endpoints (`/artist/approval/*`) handled by the new `ApprovalController`.

## 🧪 Testing Plan
1. **Pre-auth Check:** Execute a checkout cycle via card; verify the database inserts `status = authorized` and sets a 24h deadline buffer.
2. **Accept/Reject API:** Manually hit PUT `/api/artist/approval/{id}/accept` and verify the entry updates cleanly.
3. **Command Expiry:** Adjust database record times past 24 hours, run `php artisan approvals:expire`, and check if statuses drop to `expired`.