### PR TITLE
Implement penalty-only rows for admin ledger and explicit artist vali…

### DIFF
--- a/app/Http/Controllers/Admin/AdminPayoutController.php
+++ b/app/Http/Controllers/Admin/AdminPayoutController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Artist;
 use App\Models\ArtistSale;
 use App\Models\EventCancellation;
 use Illuminate\Http\JsonResponse;
@@ -19,7 +20,9 @@ class AdminPayoutController extends Controller
 
         $artistPenalties = EventCancellation::select(
                 'event_cancellations.*',
-                'artist_sales.artist_id'
+                'artist_sales.artist_id',
+                'artist_sales.event_date',
+                'artist_sales.event_hour'
             )
             ->join('artist_sales', 'event_cancellations.artist_sale_id', '=', 'artist_sales.id')
             ->where('event_cancellations.penalty_paid', false)
@@ -62,6 +65,7 @@ class AdminPayoutController extends Controller
                 'event_date' => $sale->event_date,
                 'event_hour' => $sale->event_hour,
                 'event_status' => $sale->event_status,
+                'is_penalty_only' => false,
                 'penalties' => $penalties->map(function ($p) {
                     return [
                         'sale_id' => $p->artist_sale_id,
@@ -84,6 +88,59 @@ class AdminPayoutController extends Controller
             ];
         });
 
+        foreach ($artistPenalties as $artistId => $penalties) {
+            if (in_array($artistId, $artistsWithShownPenalties)) {
+                continue;
+            }
+
+            $totalPenalties = $penalties->sum('penalty_amount');
+            if ($totalPenalties <= 0) {
+                continue;
+            }
+
+            $artist = Artist::with('payoutMethod')->find($artistId);
+            if (!$artist) {
+                continue;
+            }
+
+            $firstPenalty = $penalties->first();
+
+            $formattedPayouts->push([
+                'sale_id' => $firstPenalty->artist_sale_id,
+                'amount' => 0,
+                'openpay_fee' => 0,
+                'platform_fee' => 0,
+                'net_artist_payout' => 0,
+                'total_penalties' => $totalPenalties,
+                'adjusted_net_payout' => -$totalPenalties,
+                'event_date' => $firstPenalty->event_date,
+                'event_hour' => $firstPenalty->event_hour,
+                'event_status' => 'cancelled',
+                'is_penalty_only' => true,
+                'penalties' => $penalties->map(function ($p) {
+                    return [
+                        'sale_id' => $p->artist_sale_id,
+                        'penalty_percentage' => $p->penalty_percentage,
+                        'penalty_amount' => $p->penalty_amount,
+                        'cancelled_at' => $p->created_at,
+                        'cancellation_reason' => $p->cancellation_reason,
+                    ];
+                })->values(),
+                'artist' => [
+                    'id' => $artist->id,
+                    'name' => $artist->name,
+                    'payout_method' => $artist->payoutMethod ? [
+                        'bank_name' => $artist->payoutMethod->bank_name,
+                        'account_holder' => $artist->payoutMethod->account_holder,
+                        'clabe' => $artist->payoutMethod->clabe,
+                        'rfc' => $artist->payoutMethod->rfc,
+                    ] : null,
+                ],
+            ]);
+        }
+        
+        $formattedPayouts = $formattedPayouts->sortByDesc('sale_id')->values();
+        
         return response()->json([
             'success' => true,
             'data' => $formattedPayouts

--- a/app/Http/Controllers/Artist/ArtistController.php
+++ b/app/Http/Controllers/Artist/ArtistController.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
 use App\Rules\ValidSocialMedia;
 use App\Models\ArtistVideo;
 use Carbon\Carbon;
+use Illuminate\Validation\ValidationException;
 
 class ArtistController extends Controller
 {
@@ -109,6 +110,12 @@ class ArtistController extends Controller
                 'success' => true,
                 'artist'  => $artist,
             ], 200);
+        } catch (ValidationException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Hay campos inválidos o faltantes en el formulario.',
+                'errors'  => $e->errors(),
+            ], 422);
         } catch (\Exception $e) {
             DB::rollback();
             return response()->json([


### PR DESCRIPTION
## 📝 Description
This Pull Request delivers critical updates to financial tracking and user onboarding flows. First, it refactors the Admin Payout ledger endpoint to inject unlinked standalone penalties from cancelled events. Second, it implements a structured `ValidationException` catcher within the onboarding endpoint to protect client-side form interactions.

---

## 🔍 Context & Problem
1. **Financial Edge Case:** When an artist cancelled an event causing a system penalty but had zero normal sales during that period, their balance statement disappeared from the admin's sight. The platform lacked a mechanism to isolate and list standalone balances owed (negative payouts).
2. **Form Validation Blindness:** Form submission errors during new artist registrations were falling straight into generic `\Exception` blocks, stripping away precise form field input error states (422 response) and returning a vague 500 error instead.

---

## 🚀 Key Changes & Architecture

### 📊 `AdminPayoutController.php` — Ledger Refactoring
- **Query Stratification:** Modified the database cursor to explicitly fetch `event_date` and `event_hour` fields from the underlying `artist_sales` table inside the penalty collection query.
- **Standalone Penalty Ingestion:** Introduced a tracking `foreach` array loop post-collection to process unrendered penalty nodes (`artistsWithShownPenalties`).
- **Dynamic DTO Generation:** Created a structured state flag (`is_penalty_only => true`) returning specialized payload structures where `amount`, `openpay_fee`, `platform_fee`, and `net_artist_payout` are initialized to `0`, while mapping negative adjusted payloads (`adjusted_net_payout = -totalPenalties`).
- **Data Consistency:** Enforced global array sorting across mixed entities via `.sortByDesc('sale_id')` to present structural updates chronologically.

### 📝 `ArtistController.php` — Form Exception Isolation
- **Explicit Catch Implementations:** Injected an explicit `catch (ValidationException $e)` trap ahead of generic database rollback safety blocks.
- **Semantic Payload Responses:** Configured the handler to gracefully output a clean HTTP 422 JSON blueprint carrying standard target arrays (`$e->errors()`) alongside human-readable contextual alerts.

---

## 🧪 Testing Checklist & Verification Steps
- [ ] **Verify Standalone Penalties:** Artificially create a record in `event_cancellations` for an artist with zero successful sales. Request the `AdminPayoutController` data array. Verify the node returns `is_penalty_only: true` with a negative balance.
- [ ] **Verify Form Error Array Output:** Fire an incomplete multi-part form payload to the registration endpoint. Confirm the server safely breaks with an HTTP 422 containing descriptive index errors instead of returning a generic error.