### PR TITLE
adapt media gallery relation in Genderscontroller

### DIFF
--- a/app/Http/Controllers/Client/GendersController.php
+++ b/app/Http/Controllers/Client/GendersController.php
@@ -56,7 +56,7 @@ class GendersController extends Controller
             $artistGender = Artist::with([
                 'musicalGenders',
                 'manager',
-                'galeryArtists',
+                'media',
                 'offers' => function ($query) {
                     $query->where('is_active', true)
                         ->where('start_date', '<=', now())


### PR DESCRIPTION
# Summary

## Overview
Updated the client-side `GendersController` to use **Spatie Media Library** for loading artist gallery assets instead of the legacy gallery relationship.

## Changes Made

### Refactored Artist Media Loading
- Replaced the `galeryArtists` relationship with the `media` relationship in the artist query.
- Aligned the client endpoint with the new media management implementation based on Spatie Media Library.
- Kept the existing eager loading structure intact while updating the source of gallery assets.

### Improved Consistency
- Standardized media retrieval across the application by using the unified `media` relationship.
- Removed the dependency on the deprecated gallery relationship, ensuring compatibility with the new gallery architecture.

## Impact
- The client API now retrieves artist gallery content through Spatie Media Library.