### PR TITLE
Implement historical records endpoint and lifecycle status alignment

### DIFF
--- a/app/Console/Commands/ExpireApprovalRequests.php
+++ b/app/Console/Commands/ExpireApprovalRequests.php
@@ -37,8 +37,10 @@ class ExpireApprovalRequests extends Command
                 }
             }
 
+            $sale->status = 'cancelled';
             $sale->approval_status = 'expired';
             $sale->event_status = 'expired';
+            $sale->approval_responded_at = Carbon::now();
             $sale->save();
             $count++;
         }

--- a/app/Http/Controllers/Artist/ApprovalController.php
+++ b/app/Http/Controllers/Artist/ApprovalController.php
@@ -45,6 +45,28 @@ class ApprovalController extends Controller
         }
     }
 
+    public function history()
+    {
+        try {
+            $user = Auth::user();
+            $artist = Artist::where('user_id', $user->id)->first();
+
+            if (!$artist) {
+                return response()->json(['success' => false, 'message' => 'Perfil de artista no encontrado'], 404);
+            }
+
+            $history = ArtistSale::where('artist_id', $artist->id)
+                ->whereIn('approval_status', ['accepted', 'rejected', 'expired'])
+                ->with('customer')
+                ->orderByDesc('approval_responded_at')
+                ->get();
+
+            return response()->json(['success' => true, 'sales' => $history]);
+        } catch (\Exception $e) {
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
+    }
+
     public function accept($id)
     {
         try {
@@ -154,7 +176,7 @@ class ApprovalController extends Controller
             $sale->status = 'cancelled';
             $sale->approval_status = 'rejected';
             $sale->approval_responded_at = Carbon::now();
-            $sale->event_status = 'expired';
+            $sale->event_status = 'rejected';
             $sale->save();
 
             return response()->json(['success' => true, 'message' => 'Solicitud rechazada']);

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -395,6 +395,7 @@ class PaymentController extends Controller
             }
             
             $sales = ArtistSale::where('artist_id', $artistId)
+                ->whereIn('event_status', ['pending', 'completed'])
                 ->select('id', 'artist_id', 'event_date', 'event_hour', 'event_hours', 'event_status', 'created_at')
                 ->get();
             

--- a/routes/api.php
+++ b/routes/api.php
@@ -81,6 +81,7 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::post('/artist/payout-method', [ArtistPayoutMethodController::class, 'store']);
     Route::put('/artist/payout-method', [ArtistPayoutMethodController::class, 'update']);
     Route::get('/artist/approval/pending', [ApprovalController::class, 'pendingRequests']);
+    Route::get('/artist/approval/history', [ApprovalController::class, 'history']);
     Route::put('/artist/approval/{id}/accept', [ApprovalController::class, 'accept']);
     Route::put('/artist/approval/{id}/reject', [ApprovalController::class, 'reject']);
     //Route for client


### PR DESCRIPTION
## 📝 Description
This Pull Request delivers a structural implementation for tracking resolved artist bookings. It adds a historical ledger endpoint for resolved requests (`accepted`, `rejected`, `expired`), corrects automated command state persistence, and builds database filters to prevent historical noise from polluting current active calculations.

---

## 🔍 Context & Problem
1. **Lack of Auditing:** Artists had no architectural view of past bookings they had already accepted, rejected, or allowed to expire.
2. **State Mismatch:** The automated cron execution file (`ExpireApprovalRequests.php`) missed setting critical event indicators (`status = 'cancelled'`), causing database anomalies. Additionally, manual explicit rejections incorrectly flagged rows as `expired` inside the `event_status` attribute rather than `rejected`.
3. **Ledger Contamination:** Payment and current schedule query matrices inside `PaymentController.php` were pulling unhandled rows, corrupting live performance metrics.

---

## 🚀 Key Changes & Architecture

### 📊 `ApprovalController.php` & `api.php` — Ledger & Traps
- **Historical Endpoint:** Exposed `/api/artist/approval/history` backed by `history()`. It explicitly fetches polymorphic `customer` relations, filters strict arrays via `whereIn('approval_status', ['accepted', 'rejected', 'expired'])`, and orders results chronologically via `orderByDesc('approval_responded_at')`.
- **Manual Rejection Overhaul:** Fixed the `reject()` handler logic. It now explicitly persists `$sale->event_status = 'rejected'` instead of leaking the automated `expired` tag.

### ⚙️ Automated Command Hardening
- **`ExpireApprovalRequests.php`:** Adjusted the command loop. When a booking timeline breaches thresholds, it synchronously forces `$sale->status = 'cancelled'` and updates timestamps via `Carbon::now()` into `approval_responded_at`.

### 🛡️ Query Matrix Protection
- **`PaymentController.php`:** Sealed data leaks by appending explicit active constraint controls (`whereIn('event_status', ['pending', 'completed'])`) to eliminate dead parameters from processing layers.

---

## 🧪 Testing Checklist & Verification Steps
- [ ] **Verify Historical Query Array:** Terminate or accept a booking. Query `/api/artist/approval/history` and verify the entry transfers to the history array carrying structural metadata and consumer names.
- [ ] **Verify Reject Lifecycle:** Trigger a manual rejection via Postman. Confirm the target record updates to `event_status: "rejected"` and `approval_status: "rejected"`.
- [ ] **Verify Command Execution Properties:** Manually force an expiration using `php artisan` and check that `approval_responded_at` matches system runtime execution limits.