### PR TITLE
rename client model, controller, routes and seeder to card

### DIFF
--- a/app/Http/Controllers/Client/CardController.php
+++ b/app/Http/Controllers/Client/CardController.php
@@ -3,12 +3,12 @@
 namespace App\Http\Controllers\Client;
 
 use App\Http\Controllers\Controller;
-use App\Models\Client;
+use App\Models\Card;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
-class ClientController extends Controller
+class CardController extends Controller
 {
     /**
      * Display a listing of the resource.
@@ -18,11 +18,11 @@ class ClientController extends Controller
     public function index()
     {
         try {
-            $client = Client::orderBy('id', 'Asc')->where('user_id', Auth::user()->id)->get();
+            $cards = Card::orderBy('id', 'Asc')->where('user_id', Auth::user()->id)->get();
 
             return response()->json([
                 'success' => true,
-                'client' => $client,
+                'cards' => $cards,
             ], 200);
         } catch (\Exception $e) {
             return response()->json([
@@ -67,19 +67,19 @@ class ClientController extends Controller
             };
 
             DB::beginTransaction();
-            $client = new Client();
-            $client->user_id = Auth::user()->id;
-            $client->number_card = $number;
-            $client->card_type = $cardType;
-            $client->name = $request->input('name');
-            $client->expiration_date = $request->input('expiration_date');
-            $client->save();
+            $card = new Card();
+            $card->user_id = Auth::user()->id;
+            $card->number_card = $number;
+            $card->card_type = $cardType;
+            $card->name = $request->input('name');
+            $card->expiration_date = $request->input('expiration_date');
+            $card->save();
 
             DB::commit();
 
             return response()->json([
                 'success' => true,
-                'client' => $client,
+                'card' => $card,
             ], 200);
         } catch (\Exception $e) {
             DB::rollback();
@@ -99,11 +99,11 @@ class ClientController extends Controller
     public function show($id)
     {
         try {
-            $client = Client::find($id);
+            $card = Card::find($id);
 
             return response()->json([
                 'success' => true,
-                'client' => $client,
+                'card' => $card,
             ], 200);
         } catch (\Exception $e) {
             return response()->json([
@@ -135,15 +135,15 @@ class ClientController extends Controller
     {
         try {
             DB::beginTransaction();
-            $client = Client::find($id);
-            $client->fill($request->all());
-            $client->save();
+            $card = Card::find($id);
+            $card->fill($request->all());
+            $card->save();
 
             DB::commit();
 
             return response()->json([
                 'success' => true,
-                'client' => $client,
+                'card' => $card,
             ], 200);
         } catch (\Exception $e) {
             DB::rollback();
@@ -164,8 +164,8 @@ class ClientController extends Controller
     {
         try {
             DB::beginTransaction();
-            $client = Client::where('id', $id)->first();
-            $client->delete();
+            $card = Card::where('id', $id)->first();
+            $card->delete();
 
             DB::commit();
             return response()->json([

--- a/app/Models/Card.php
+++ b/app/Models/Card.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Client extends Model
+class Card extends Model
 {
     use HasFactory;
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -103,9 +103,9 @@ class User extends Authenticatable implements JWTSubject, MustVerifyEmail, HasMe
        return $this->hasOne(Artist::class);
     }
 
-    public function clients()
+    public function cards()
     {
-       return $this->hasMany(Client::class);
+       return $this->hasMany(Card::class);
     }
 
     public function historyShoppings()

--- a/database/migrations/2026_07_06_122101_rename_clients_to_cards_table.php
+++ b/database/migrations/2026_07_06_122101_rename_clients_to_cards_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename('clients', 'cards');
+
+        DB::statement('ALTER SEQUENCE clients_id_seq RENAME TO cards_id_seq;');
+        DB::statement('ALTER INDEX clients_pkey RENAME TO cards_pkey;');
+        DB::statement('ALTER TABLE cards RENAME CONSTRAINT clients_user_id_foreign TO cards_user_id_foreign;');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement('ALTER TABLE cards RENAME CONSTRAINT cards_user_id_foreign TO clients_user_id_foreign;');
+        DB::statement('ALTER INDEX cards_pkey RENAME TO clients_pkey;');
+        DB::statement('ALTER SEQUENCE cards_id_seq RENAME TO clients_id_seq;');
+
+        Schema::rename('cards', 'clients');
+    }
+};

--- a/database/migrations/2026_07_06_122101_rename_clients_to_cards_table.php
+++ b/database/migrations/2026_07_06_122101_rename_clients_to_cards_table.php
@@ -14,11 +14,15 @@ return new class extends Migration
      */
     public function up()
     {
+        Schema::table('clients', function (Blueprint $table) {
+            $table->dropForeign('clients_user_id_foreign');
+        });
         Schema::rename('clients', 'cards');
-
         DB::statement('ALTER SEQUENCE clients_id_seq RENAME TO cards_id_seq;');
         DB::statement('ALTER INDEX clients_pkey RENAME TO cards_pkey;');
-        DB::statement('ALTER TABLE cards RENAME CONSTRAINT clients_user_id_foreign TO cards_user_id_foreign;');
+        Schema::table('cards', function (Blueprint $table) {
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
     }
 
     /**
@@ -28,10 +32,16 @@ return new class extends Migration
      */
     public function down()
     {
-        DB::statement('ALTER TABLE cards RENAME CONSTRAINT cards_user_id_foreign TO clients_user_id_foreign;');
+        Schema::table('cards', function (Blueprint $table) {
+            $table->dropForeign('cards_user_id_foreign');
+        });
+
         DB::statement('ALTER INDEX cards_pkey RENAME TO clients_pkey;');
         DB::statement('ALTER SEQUENCE cards_id_seq RENAME TO clients_id_seq;');
 
         Schema::rename('cards', 'clients');
+        Schema::table('clients', function (Blueprint $table) {
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
     }
 };

--- a/database/seeders/CardSeeder.php
+++ b/database/seeders/CardSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use App\Models\Client;
+use App\Models\Card;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
@@ -16,7 +16,7 @@ class CardSeeder extends Seeder
      */
     public function run()
     {
-        DB::statement('TRUNCATE TABLE clients RESTART IDENTITY CASCADE;');
+        DB::statement('TRUNCATE TABLE cards RESTART IDENTITY CASCADE;');
 
         $users = User::whereHas('roles', function ($query) {
             $query->where('slug', User::ROLE_CLIENT);
@@ -34,7 +34,7 @@ class CardSeeder extends Seeder
         foreach ($users as $index => $user) {
             $card = $cards[$index % count($cards)];
 
-            Client::create([
+            Card::create([
                 'user_id' => $user->id,
                 'number_card' => $card['number'],
                 'name' => $user->name,

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,7 +5,7 @@ use App\Http\Controllers\Admin\MusicalsGendersController;
 use App\Http\Controllers\Artist\ArtistController;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\QuotationsController;
-use App\Http\Controllers\Client\ClientController;
+use App\Http\Controllers\Client\CardController;
 use App\Http\Controllers\Client\FavouriteArtist\FavouriteArtistsController;
 use App\Http\Controllers\Client\PaymentController as ClientPaymentController;
 use App\Http\Controllers\Client\GendersController;
@@ -84,8 +84,8 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::put('/artist/approval/{id}/accept', [ApprovalController::class, 'accept']);
     Route::put('/artist/approval/{id}/reject', [ApprovalController::class, 'reject']);
     //Route for client
-    Route::resource('/client-card', ClientController::class);
-    Route::get('/client/profile', [ClientController::class, 'getProfile']);
+    Route::resource('/cards', CardController::class);
+    Route::get('/client/profile', [CardController::class, 'getProfile']);
     Route::get('/client/musical-genders', [GendersController::class, 'index']);
     Route::get('/client/musical-genders/{slug}', [GendersController::class, 'artistsGenders']);
     Route::get('/client/musical-genders/artist/{slug}', [GendersController::class, 'artistGender']);


### PR DESCRIPTION
# Summary

## Refactored Client Card Management

- Renamed the card management module to use **Card** instead of **Client** for better domain clarity and consistency.
- Replaced `ClientController` with a new `CardController` while preserving the existing card management functionality, including CRUD operations and user profile retrieval.
- Replaced the `Client` model with a new `Card` model to better represent payment card data.

## Database Updates

- Added a new migration to rename the `clients` table to `cards`, aligning the database structure with the new naming convention.
- Updated the card seeder to populate the renamed `cards` table instead of `clients`.
- Modified the seeder to use the new `Card` model when generating sample payment card records.

## User Model Improvements

- Renamed the `clients()` relationship in the `User` model to `cards()` to reflect the new model name.
- Updated the relationship to reference the new `Card` model while maintaining the same one-to-many association between users and their payment cards.

## API Refactoring

- Updated API imports to reference `CardController` instead of `ClientController`.
- Renamed the payment card resource endpoint from `/client-card` to `/cards` to provide a cleaner and more RESTful API structure.
- Updated the client profile endpoint to use the new `CardController`.

## Codebase Consistency

- Standardized naming across controllers, models, database seeders, relationships, routes, and API resources by replacing the old **Client** card-related implementation with the new **Card** terminology.
