### PR TITLE
Implement standalone penalty tracking and include event schedules in cancellations

### DIFF
--- a/app/Http/Controllers/Artist/OfferController.php
+++ b/app/Http/Controllers/Artist/OfferController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Artist;
 
 use App\Http\Controllers\Controller;
 use App\Models\Artist;
+use App\Models\ArtistSale;
 use App\Models\Offer;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -16,6 +17,13 @@ class OfferController extends Controller
         try {
             $artist = Artist::where('user_id', Auth::user()->id)->firstOrFail();
             $offers = Offer::where('artist_id', $artist->id)->orderBy('created_at', 'desc')->get();
+
+            $offers->each(function ($offer) {
+                $offer->has_pending_sale = ArtistSale::where('offer_id', $offer->id)
+                    ->where('approval_status', 'pending_approval')
+                    ->exists();
+            });
+
             return response()->json(['success' => true, 'offers' => $offers], 200);
         } catch (\Exception $e) {
             return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
@@ -81,6 +89,18 @@ class OfferController extends Controller
         try {
             $artist = Artist::where('user_id', Auth::user()->id)->firstOrFail();
             $offer = Offer::where('id', $id)->where('artist_id', $artist->id)->firstOrFail();
+
+            $hasPendingSale = ArtistSale::where('offer_id', $offer->id)
+                ->where('approval_status', 'pending_approval')
+                ->exists();
+
+            if ($hasPendingSale) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'No puedes eliminar esta oferta: hay una venta en espera de tu respuesta (aceptar/rechazar) que la utilizó. Podrás eliminarla una vez que esa solicitud se resuelva.',
+                ], 422);
+            }
+
             $offer->delete();
             return response()->json(['success' => true, 'message' => 'Oferta eliminada'], 200);
         } catch (\Exception $e) {

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -125,6 +125,7 @@ class PaymentController extends Controller
 
                 $itemsForSales[] = [
                     'artist_id' => $artistId,
+                    'offer_id' => $activeOffer?->id,
                     'amount' => $lineTotalPesos,
                     'hours' => $hours,
                     'extra_km_distance' => $extraKmDistance,
@@ -238,6 +239,7 @@ class PaymentController extends Controller
                     $sale = new ArtistSale();
                     $sale->openpay_transaction_id = $charge->id;
                     $sale->artist_id = $item['artist_id'];
+                    $sale->offer_id = $item['offer_id'] ?? null;
                     $sale->customer_id = $userId;
                     $sale->amount = $item['amount'];
                     $sale->openpay_fee = $this->resolveOpenpayFee($charge, (float) $item['amount']);
@@ -759,6 +761,7 @@ class PaymentController extends Controller
 
                 $itemsForSales[] = [
                     'artist_id' => $artistId,
+                    'offer_id' => $activeOffer?->id,
                     'amount' => $lineTotalPesos,
                     'event_date' => $normalizedEventDate,
                     'event_hour' => $normalizedEventHour,
@@ -826,6 +829,7 @@ class PaymentController extends Controller
                     $sale->status = 'pending';
                     $sale->event_status = 'pending';
                     $sale->artist_id              = $item['artist_id'];
+                    $sale->offer_id               = $item['offer_id'] ?? null;
                     $sale->customer_id            = $userId;
                     $sale->amount                 = $item['amount'];
                     $sale->customer_first_name    = $name;

--- a/app/Models/ArtistSale.php
+++ b/app/Models/ArtistSale.php
@@ -9,6 +9,7 @@ class ArtistSale extends Model
 {
     protected $fillable = [
         'artist_id',
+        'offer_id',
         'customer_id',
         'amount',
         'openpay_fee',
@@ -41,6 +42,11 @@ class ArtistSale extends Model
     public function artist()
     {
         return $this->belongsTo(Artist::class, 'artist_id');
+    }
+
+    public function offer()
+    {
+        return $this->belongsTo(Offer::class, 'offer_id');
     }
 
     public function customer()

--- a/app/Models/Offer.php
+++ b/app/Models/Offer.php
@@ -25,4 +25,9 @@ class Offer extends Model
     {
         return $this->belongsTo(Artist::class);
     }
+
+    public function sales()
+    {
+        return $this->hasMany(ArtistSale::class, 'offer_id');
+    }
 }

--- a/database/migrations/2026_07_09_000001_add_offer_id_to_artist_sales_table.php
+++ b/database/migrations/2026_07_09_000001_add_offer_id_to_artist_sales_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+class AddOfferIdToArtistSalesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('artist_sales', function (Blueprint $table) {
+            $table->unsignedBigInteger('offer_id')->nullable()->after('artist_id');
+            $table->foreign('offer_id')->references('id')->on('offers')->onDelete('set null');
+        });
+    }
+
+    public function down()
+    {
+        DB::statement('ALTER TABLE artist_sales DROP CONSTRAINT IF EXISTS artist_sales_offer_id_foreign CASCADE');
+
+        Schema::table('artist_sales', function (Blueprint $table) {
+            $table->dropColumn('offer_id');
+        });
+    }
+}


### PR DESCRIPTION
## 📝 Description
This Pull Request introduces a vital safeguard for the Commerce engine by officially linking `ArtistSale` records to `Offer` records. Previously, deleting an offer that was actively tied to a pending transaction could cause data integrity issues or confuse the client/artist flow. Now, the system explicitly blocks artists from deleting offers that are currently in a "pending approval" state for an active sale.

---

## 🔍 Context & Problem
1. **Unlinked Sales:** Transactions (`ArtistSale`) were not properly storing the `offer_id` when an offer was applied at checkout.
2. **Unsafe Deletions:** Artists could delete an offer from their dashboard even if a client had just purchased a service using that offer (and the request was still pending approval), leading to broken references.

---

## 🚀 Key Changes & Architecture

### 🗄️ Database & Models
- Added `offer_id` column to the `artist_sales` table (via migration).
- Updated `ArtistSale` and `Offer` models with their respective relationships (`offer()` and `sales()`).
- Whitelisted `offer_id` in the `$fillable` array of `ArtistSale`.

### 💳 Payment Controller Integration
- The `PaymentController` now actively maps and injects `$activeOffer?->id` into the `ArtistSale` payload during the checkout and charge sequence.

### 🛡️ Controller Safeguards (`OfferController`)
- **Validation:** Added an explicit check before deleting an offer (`destroy` method). If `hasPendingSale` evaluates to true, the API responds with a `422 Unprocessable Entity` and a descriptive message.
- **Data Enrichment:** The `index` method now appends a boolean `has_pending_sale` to each offer, allowing the Frontend to proactively react to this state.

---

## 🧪 Testing Checklist
- [ ] Process a checkout using an active offer. Verify that `offer_id` is successfully saved in the `artist_sales` table.
- [ ] Log in as an artist who has an offer currently tied to a pending sale. Attempt to delete it via API/Postman. Verify you receive a `422` error with the blocking message.