### PR TITLE
Feature: Replace event status values with centralized model constants

### DIFF
--- a/app/Console/Commands/ExpireApprovalRequests.php
+++ b/app/Console/Commands/ExpireApprovalRequests.php
@@ -16,7 +16,7 @@ class ExpireApprovalRequests extends Command
 
     public function handle()
     {
-        $expired = ArtistSale::where('approval_status', 'pending_approval')
+        $expired = ArtistSale::where('approval_status', ArtistSale::APPROVAL_STATUS_PENDING)
             ->whereNotNull('approval_deadline')
             ->where('approval_deadline', '<', Carbon::now())
             ->get();
@@ -37,9 +37,9 @@ class ExpireApprovalRequests extends Command
                 }
             }
 
-            $sale->status = 'cancelled';
-            $sale->approval_status = 'expired';
-            $sale->event_status = 'expired';
+            $sale->status = ArtistSale::PAYMENT_STATUS_CANCELLED;
+            $sale->approval_status = ArtistSale::APPROVAL_STATUS_EXPIRED;
+            $sale->event_status = ArtistSale::EVENT_STATUS_EXPIRED;
             $sale->approval_responded_at = Carbon::now();
             $sale->save();
             $count++;

--- a/app/Http/Controllers/Admin/AdminPayoutController.php
+++ b/app/Http/Controllers/Admin/AdminPayoutController.php
@@ -14,8 +14,8 @@ class AdminPayoutController extends Controller
     public function pendingPayouts(): JsonResponse
     {
         $sales = ArtistSale::with(['artist.payoutMethod'])
-            ->where('status', 'completed')
-            ->where('event_status', '!=', 'cancelled')
+            ->where('status', ArtistSale::PAYMENT_STATUS_COMPLETED)
+            ->where('event_status', '!=', ArtistSale::EVENT_STATUS_CANCELLED)
             ->get();
 
         $artistPenalties = EventCancellation::select(
@@ -115,7 +115,7 @@ class AdminPayoutController extends Controller
                 'adjusted_net_payout' => -$totalPenalties,
                 'event_date' => $firstPenalty->event_date,
                 'event_hour' => $firstPenalty->event_hour,
-                'event_status' => 'cancelled',
+                'event_status' => ArtistSale::EVENT_STATUS_CANCELLED,
                 'is_penalty_only' => true,
                 'penalties' => $penalties->map(function ($p) {
                     return [
@@ -157,21 +157,21 @@ class AdminPayoutController extends Controller
             ], 404);
         }
 
-        if ($sale->event_status !== 'completed') {
+        if ($sale->event_status !== ArtistSale::EVENT_STATUS_COMPLETED) {
             return response()->json([
                 'success' => false,
                 'message' => 'El evento físico aún no ha sido marcado como completado.'
             ], 400);
         }
 
-        if ($sale->status === 'liquidated') {
+        if ($sale->status === ArtistSale::PAYMENT_STATUS_LIQUIDATED) {
             return response()->json([
                 'success' => false,
                 'message' => 'Esta liquidación ya fue pagada anteriormente.'
             ], 400);
         }
 
-        $sale->status = 'liquidated';
+        $sale->status = ArtistSale::PAYMENT_STATUS_LIQUIDATED;
         $sale->save();
 
         EventCancellation::whereIn('artist_sale_id', function ($query) use ($sale) {

--- a/app/Http/Controllers/Artist/ApprovalController.php
+++ b/app/Http/Controllers/Artist/ApprovalController.php
@@ -27,7 +27,7 @@ class ApprovalController extends Controller
             }
 
             $pending = ArtistSale::where('artist_id', $artist->id)
-                ->where('approval_status', 'pending_approval')
+                ->where('approval_status', ArtistSale::APPROVAL_STATUS_PENDING)
                 ->whereNotNull('approval_deadline')
                 ->where('approval_deadline', '>', Carbon::now())
                 ->with('customer')
@@ -58,7 +58,7 @@ class ApprovalController extends Controller
             }
 
             $history = ArtistSale::where('artist_id', $artist->id)
-                ->whereIn('approval_status', ['accepted', 'rejected', 'expired'])
+                ->whereIn('approval_status', [ArtistSale::APPROVAL_STATUS_ACCEPTED, ArtistSale::APPROVAL_STATUS_REJECTED, ArtistSale::APPROVAL_STATUS_EXPIRED])
                 ->with('customer')
                 ->orderByDesc('approval_responded_at')
                 ->get();
@@ -81,7 +81,7 @@ class ApprovalController extends Controller
 
             $sale = ArtistSale::where('id', $id)
                 ->where('artist_id', $artist->id)
-                ->where('approval_status', 'pending_approval')
+                ->where('approval_status', ArtistSale::APPROVAL_STATUS_PENDING)
                 ->first();
 
             if (!$sale) {
@@ -89,7 +89,7 @@ class ApprovalController extends Controller
             }
 
             if (Carbon::now()->gt(Carbon::parse($sale->approval_deadline))) {
-                $sale->approval_status = 'expired';
+                $sale->approval_status = ArtistSale::APPROVAL_STATUS_EXPIRED;
                 $sale->save();
                 return response()->json(['success' => false, 'message' => 'El tiempo para responder ha expirado'], 422);
             }
@@ -136,12 +136,12 @@ class ApprovalController extends Controller
                 $sale->cash_due_date = Carbon::now()->addHours(24);
             }
 
-            $sale->status = $sale->payment_method === 'card' ? 'completed' : 'pending';
-            $sale->approval_status = 'accepted';
+            $sale->status = $sale->payment_method === 'card' ? ArtistSale::PAYMENT_STATUS_COMPLETED : ArtistSale::PAYMENT_STATUS_PENDING;
+            $sale->approval_status = ArtistSale::APPROVAL_STATUS_ACCEPTED;
             $sale->approval_responded_at = Carbon::now();
             $sale->save();
 
-            $this->sendClientNotification($sale, 'accepted');
+            $this->sendClientNotification($sale, ArtistSale::APPROVAL_STATUS_ACCEPTED);
 
             return response()->json(['success' => true, 'message' => 'Solicitud aceptada correctamente', 'sale' => $sale]);
         } catch (\Exception $e) {
@@ -170,7 +170,7 @@ class ApprovalController extends Controller
 
             $sale = ArtistSale::where('id', $id)
                 ->where('artist_id', $artist->id)
-                ->where('approval_status', 'pending_approval')
+                ->where('approval_status', ArtistSale::APPROVAL_STATUS_PENDING)
                 ->first();
 
             if (!$sale) {
@@ -189,13 +189,13 @@ class ApprovalController extends Controller
                 }
             }
             
-            $sale->status = 'cancelled';
-            $sale->approval_status = 'rejected';
+            $sale->status = ArtistSale::PAYMENT_STATUS_CANCELLED;
+            $sale->approval_status = ArtistSale::APPROVAL_STATUS_REJECTED;
             $sale->approval_responded_at = Carbon::now();
-            $sale->event_status = 'rejected';
+            $sale->event_status = ArtistSale::EVENT_STATUS_REJECTED;
             $sale->save();
 
-            $this->sendClientNotification($sale, 'rejected');
+            $this->sendClientNotification($sale, ArtistSale::APPROVAL_STATUS_REJECTED);
 
             return response()->json(['success' => true, 'message' => 'Solicitud rechazada']);
         } catch (\Exception $e) {

--- a/app/Http/Controllers/Artist/OfferController.php
+++ b/app/Http/Controllers/Artist/OfferController.php
@@ -20,7 +20,7 @@ class OfferController extends Controller
 
             $offers->each(function ($offer) {
                 $offer->has_pending_sale = ArtistSale::where('offer_id', $offer->id)
-                    ->where('approval_status', 'pending_approval')
+                    ->where('approval_status', ArtistSale::APPROVAL_STATUS_PENDING)
                     ->exists();
             });
 
@@ -91,7 +91,7 @@ class OfferController extends Controller
             $offer = Offer::where('id', $id)->where('artist_id', $artist->id)->firstOrFail();
 
             $hasPendingSale = ArtistSale::where('offer_id', $offer->id)
-                ->where('approval_status', 'pending_approval')
+                ->where('approval_status', ArtistSale::APPROVAL_STATUS_PENDING)
                 ->exists();
 
             if ($hasPendingSale) {

--- a/app/Http/Controllers/ArtistRatingController.php
+++ b/app/Http/Controllers/ArtistRatingController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace App\Http\Controllers;
 
 use App\Models\Artist;
@@ -20,7 +19,7 @@ class ArtistRatingController extends Controller
                                 ->where('customer_id', auth()->id())
                                 ->firstOrFail();
 
-        if ($artistSale->event_status !== 'completed' && $artistSale->status !== 'completed') {
+        if ($artistSale->event_status !== ArtistSale::EVENT_STATUS_COMPLETED && $artistSale->status !== ArtistSale::PAYMENT_STATUS_COMPLETED) {
             return response()->json([
                 'success' => false,
                 'message' => 'Solo puedes calificar eventos que ya han finalizado.'

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -173,7 +173,7 @@ class PaymentController extends Controller
                 $alreadyBooked = DB::table('artist_sales')
                     ->where('artist_id', $item['artist_id'])
                     ->where('event_date', $item['event_date'])
-                    ->whereIn('event_status', ['pending', 'completed'])
+                    ->whereIn('event_status', [ArtistSale::EVENT_STATUS_PENDING, ArtistSale::EVENT_STATUS_COMPLETED])
                     ->exists();
 
                 if ($alreadyBooked) {
@@ -254,15 +254,15 @@ class PaymentController extends Controller
                     $sale->event_date = $item['event_date'];
                     $sale->event_hour = $item['event_hour'];
                     $sale->event_hours = $item['hours'] ?? null;
-                    $sale->event_status = 'pending';
-                    $sale->status = 'authorized';
+                    $sale->event_status = ArtistSale::EVENT_STATUS_PENDING;
+                    $sale->status = ArtistSale::PAYMENT_STATUS_AUTHORIZED;
                     $sale->payment_method = 'card';
                     $sale->latitude = $latitude;
                     $sale->longitude = $longitude;
                     $sale->google_place_id = $googlePlaceId;
                     $sale->extra_km_distance = $item['extra_km_distance'];
                     $sale->extra_km_cost = $item['extra_km_cost'];
-                    $sale->approval_status = 'pending_approval';
+                    $sale->approval_status = ArtistSale::APPROVAL_STATUS_PENDING;
                     $sale->approval_deadline = Carbon::now()->addHours(24);
                     $sale->openpay_customer_id = $charge->customer->id ?? null;
                     $sale->save();
@@ -402,7 +402,7 @@ class PaymentController extends Controller
             }
             
             $sales = ArtistSale::where('artist_id', $artistId)
-                ->whereIn('event_status', ['pending', 'completed'])
+                ->whereIn('event_status', [ArtistSale::EVENT_STATUS_PENDING, ArtistSale::EVENT_STATUS_COMPLETED])
                 ->select('id', 'artist_id', 'event_date', 'event_hour', 'event_hours', 'event_status', 'created_at')
                 ->get();
             
@@ -442,7 +442,7 @@ class PaymentController extends Controller
             $sales = ArtistSale::where('artist_id', $artist->id)
                 ->where(function ($query) {
                     $query->whereNull('approval_status')
-                          ->orWhere('approval_status', '!=', 'pending_approval');
+                          ->orWhere('approval_status', '!=', ArtistSale::APPROVAL_STATUS_PENDING);
                 })
                 ->get();
             
@@ -530,11 +530,11 @@ class PaymentController extends Controller
                 return response()->json(['success' => false, 'message' => 'Sale not found'], 404);
             }
 
-            if ($sale->event_status === 'completed') {
+            if ($sale->event_status === ArtistSale::EVENT_STATUS_COMPLETED) {
                 return response()->json(['success' => false, 'message' => 'Evento ya completado'], 400);
             }
 
-            if ($sale->event_status === 'expired') {
+            if ($sale->event_status === ArtistSale::EVENT_STATUS_EXPIRED) {
                 return response()->json(['success' => false, 'message' => 'Evento expirado, no se puede marcar como completado'], 400);
             }
 
@@ -542,7 +542,7 @@ class PaymentController extends Controller
                 return response()->json(['success' => false, 'message' => 'El evento aún no ha terminado. Debes esperar a la hora de finalización.'], 400);
             }
 
-            $sale->event_status = 'completed';
+            $sale->event_status = ArtistSale::EVENT_STATUS_COMPLETED;
             $sale->save();
 
             return response()->json(['success' => true, 'message' => 'Evento marcado como completado']);
@@ -557,7 +557,7 @@ class PaymentController extends Controller
             $now = Carbon::now();
             $cutoff = $now->copy()->subDay();
 
-            $expiredSales = ArtistSale::where('event_status', 'pending')
+            $expiredSales = ArtistSale::where('event_status', ArtistSale::EVENT_STATUS_PENDING)
                 ->whereNotNull('event_date')
                 ->whereNotNull('event_hour')
                 ->get()
@@ -572,7 +572,7 @@ class PaymentController extends Controller
 
             $count = 0;
             foreach ($expiredSales as $sale) {
-                $sale->event_status = 'expired';
+                $sale->event_status = ArtistSale::EVENT_STATUS_EXPIRED;
                 $sale->save();
                 $count++;
             }
@@ -614,20 +614,20 @@ class PaymentController extends Controller
 
     private function computeStatus($sale)
     {
-        if ($sale->event_status === 'completed') {
-            return 'completed';
+        if ($sale->event_status === ArtistSale::EVENT_STATUS_COMPLETED) {
+            return ArtistSale::EVENT_STATUS_COMPLETED;
         }
 
-        if ($sale->event_status === 'expired') {
-            return 'expired';
+        if ($sale->event_status === ArtistSale::EVENT_STATUS_EXPIRED) {
+            return ArtistSale::EVENT_STATUS_EXPIRED;
         }
 
-        if ($sale->event_status === 'cancelled') {
-            return 'cancelled';
+        if ($sale->event_status === ArtistSale::EVENT_STATUS_CANCELLED) {
+            return ArtistSale::EVENT_STATUS_CANCELLED;
         }
 
         if (!$sale->event_date || !$sale->event_hour) {
-            return 'pending';
+            return ArtistSale::EVENT_STATUS_PENDING;
         }
 
         $now = Carbon::now();
@@ -640,9 +640,9 @@ class PaymentController extends Controller
         if ($eventEnd < $now) {
             $cutoff = $eventEnd->copy()->addDay();
             if ($now > $cutoff) {
-                $sale->event_status = 'expired';
+                $sale->event_status = ArtistSale::EVENT_STATUS_EXPIRED;
                 $sale->save();
-                return 'expired';
+                return ArtistSale::EVENT_STATUS_EXPIRED;
             }
         }
 
@@ -651,7 +651,7 @@ class PaymentController extends Controller
 
     private function canComplete($sale)
     {
-        if ($sale->event_status !== 'pending') return false;
+        if ($sale->event_status !== ArtistSale::EVENT_STATUS_PENDING) return false;
         if (!$sale->event_date || !$sale->event_hour) return false;
 
         $now = Carbon::now();
@@ -685,7 +685,7 @@ class PaymentController extends Controller
                 ], 404);
             }
 
-            $salesQuery = ArtistSale::where('artist_id', $artist->id)->where('status', 'completed');
+            $salesQuery = ArtistSale::where('artist_id', $artist->id)->where('status', ArtistSale::PAYMENT_STATUS_COMPLETED);
             $total = (float) $salesQuery->sum('amount');
             $count = (clone $salesQuery)->count();
 
@@ -829,7 +829,7 @@ class PaymentController extends Controller
                 $alreadyBooked = DB::table('artist_sales')
                     ->where('artist_id', $item['artist_id'])
                     ->where('event_date', $item['event_date'])
-                    ->whereIn('event_status', ['pending', 'completed'])
+                    ->whereIn('event_status', [ArtistSale::EVENT_STATUS_PENDING, ArtistSale::EVENT_STATUS_COMPLETED])
                     ->exists();
 
                 if ($alreadyBooked) {
@@ -847,8 +847,8 @@ class PaymentController extends Controller
             try {
                 foreach ($itemsForSales as $item) {
                     $sale = new ArtistSale();
-                    $sale->status = 'pending';
-                    $sale->event_status = 'pending';
+                    $sale->status = ArtistSale::PAYMENT_STATUS_PENDING;
+                    $sale->event_status = ArtistSale::EVENT_STATUS_PENDING;
                     $sale->artist_id              = $item['artist_id'];
                     $sale->offer_id               = $item['offer_id'] ?? null;
                     $sale->customer_id            = $userId;
@@ -871,7 +871,7 @@ class PaymentController extends Controller
                     $sale->google_place_id = $googlePlaceId;
                     $sale->extra_km_distance = $item['extra_km_distance'];
                     $sale->extra_km_cost = $item['extra_km_cost'];
-                    $sale->approval_status = 'pending_approval';
+                    $sale->approval_status = ArtistSale::APPROVAL_STATUS_PENDING;
                     $sale->approval_deadline = Carbon::now()->addHours(24);
                     $sale->save();
 
@@ -937,11 +937,11 @@ class PaymentController extends Controller
                 return response()->json(['error' => 'Venta no encontrada o no es un pago en efectivo'], 404);
             }
 
-            if ($sale->status === 'completed') {
+            if ($sale->status === ArtistSale::PAYMENT_STATUS_COMPLETED) {
                 return response()->json(['error' => 'Esta venta ya fue pagada'], 400);
             }
 
-            if ($sale->approval_status !== 'accepted') {
+            if ($sale->approval_status !== ArtistSale::APPROVAL_STATUS_ACCEPTED) {
                 return response()->json(['error' => 'El artista aún no ha aceptado esta solicitud'], 422);
             }
 
@@ -1070,14 +1070,14 @@ class PaymentController extends Controller
             return response()->json(['message' => 'No se encontró la transacción en el sistema'], 404);
         }
 
-        if ($sale->status === 'completed') {
+        if ($sale->status === ArtistSale::PAYMENT_STATUS_COMPLETED) {
             return response()->json([
                 'message' => 'El pago ya había sido confirmado previamente',
                 'updated' => 0,
             ], 200);
         }
 
-        $sale->status = 'completed';
+        $sale->status = ArtistSale::PAYMENT_STATUS_COMPLETED;
         $sale->save();
 
         return response()->json([
@@ -1106,11 +1106,11 @@ class PaymentController extends Controller
                 return response()->json(['success' => false, 'message' => 'Venta no encontrada'], 404);
             }
 
-            if ($sale->event_status === 'completed') {
+            if ($sale->event_status === ArtistSale::EVENT_STATUS_COMPLETED) {
                 return response()->json(['success' => false, 'message' => 'El evento ya fue completado'], 400);
             }
 
-            if ($sale->event_status === 'cancelled') {
+            if ($sale->event_status === ArtistSale::EVENT_STATUS_CANCELLED) {
                 return response()->json(['success' => false, 'message' => 'El evento ya fue cancelado'], 400);
             }
 
@@ -1143,7 +1143,7 @@ class PaymentController extends Controller
 
             $penaltyAmount = round($amount * ($penaltyPercentage / 100), 2);
 
-            if ($sale->payment_method === 'card' && $sale->openpay_transaction_id && $sale->status === 'completed') {
+            if ($sale->payment_method === 'card' && $sale->openpay_transaction_id && $sale->status === ArtistSale::PAYMENT_STATUS_COMPLETED) {
                 try {
                     $keys = OpenpayKey::first();
                     $openpay = Openpay::getInstance($keys->openpay_id, $keys->openpay_secret, "MX", $request->ip());
@@ -1157,7 +1157,7 @@ class PaymentController extends Controller
                 }
             }
 
-            $sale->event_status = 'cancelled';
+            $sale->event_status = ArtistSale::EVENT_STATUS_CANCELLED;
             $sale->save();
 
             EventCancellation::create([
@@ -1201,11 +1201,11 @@ class PaymentController extends Controller
                 return response()->json(['success' => false, 'message' => 'Compra no encontrada'], 404);
             }
 
-            if ($sale->event_status === 'completed') {
+            if ($sale->event_status === ArtistSale::EVENT_STATUS_COMPLETED) {
                 return response()->json(['success' => false, 'message' => 'El evento ya fue completado'], 400);
             }
 
-            if ($sale->event_status === 'cancelled') {
+            if ($sale->event_status === ArtistSale::EVENT_STATUS_CANCELLED) {
                 return response()->json(['success' => false, 'message' => 'El evento ya fue cancelado'], 400);
             }
 
@@ -1228,7 +1228,7 @@ class PaymentController extends Controller
             $amount = floatval($sale->amount);
             $penaltyPercentage = 0;
 
-            if ($sale->approval_status === 'accepted') {
+            if ($sale->approval_status === ArtistSale::APPROVAL_STATUS_ACCEPTED) {
                 if ($daysUntilEvent >= 3 && $daysUntilEvent < 7) {
                     $penaltyPercentage = 25;
                 }
@@ -1245,7 +1245,7 @@ class PaymentController extends Controller
             $originalPenaltyAmount = $penaltyAmount;
             $originalRefundAmount = $refundAmount;
 
-            if ($sale->payment_method === 'card' && $sale->openpay_transaction_id && $sale->status === 'completed') {
+            if ($sale->payment_method === 'card' && $sale->openpay_transaction_id && $sale->status === ArtistSale::PAYMENT_STATUS_COMPLETED) {
                 try {
                     $keys = OpenpayKey::first();
                     $openpay = Openpay::getInstance($keys->openpay_id, $keys->openpay_secret, "MX", $request->ip());
@@ -1281,7 +1281,7 @@ class PaymentController extends Controller
             $penaltyAmount = $originalPenaltyAmount;
             $refundAmount = $originalRefundAmount;
 
-            $sale->event_status = 'cancelled';
+            $sale->event_status = ArtistSale::EVENT_STATUS_CANCELLED;
             $sale->save();
 
             EventCancellation::create([
@@ -1317,7 +1317,7 @@ class PaymentController extends Controller
         $artistUser = Artist::where('id', $sale->artist_id)->with('user')->first()?->user;
         $artistEmail = $artistUser ? $artistUser->email : null;
 
-        $isBeforeApproval = $cancelledBy === 'client' && $sale->approval_status !== 'accepted';
+        $isBeforeApproval = $cancelledBy === 'client' && $sale->approval_status !== ArtistSale::APPROVAL_STATUS_ACCEPTED;
 
         if ($clientEmail) {
             try {

--- a/app/Mail/ArtistApprovalNotification.php
+++ b/app/Mail/ArtistApprovalNotification.php
@@ -24,7 +24,7 @@ class ArtistApprovalNotification extends Mailable
 
     public function build()
     {
-        $subject = $this->status === 'accepted'
+        $subject = $this->status === ArtistSale::APPROVAL_STATUS_ACCEPTED
             ? 'Solicitud de evento aceptada - Vibeer'
             : 'Solicitud de evento rechazada - Vibeer';
 


### PR DESCRIPTION
**Summary**

This PR refactors the event management workflow by replacing hardcoded event status values with the centralized constants defined in the corresponding models.

The update standardizes status handling across the application, improving consistency, readability, and maintainability while reducing the risk of errors caused by duplicated string values.

**📁 Files Modified**
Backend

Console

- app/Console/Commands/ExpireApprovalRequests.php

Controllers

- app/Http/Controllers/Admin/AdminPayoutController.php
- app/Http/Controllers/Artist/ApprovalController.php
- app/Http/Controllers/Artist/OfferController.php
- app/Http/Controllers/ArtistRatingController.php
- app/Http/Controllers/PaymentController.php

Mail

- app/Mail/ArtistApprovalNotification.php