### PR TITLE
Extract cash reference attributes to independent model and table

### DIFF
--- a/app/Http/Controllers/Artist/ApprovalController.php
+++ b/app/Http/Controllers/Artist/ApprovalController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Artist;
 
 use App\Http\Controllers\Controller;
 use App\Models\ArtistSale;
+use App\Models\ArtistSaleCashReference;
 use App\Models\Artist;
 use App\Models\OpenpayKey;
 use Illuminate\Http\Request;
@@ -131,15 +132,24 @@ class ApprovalController extends Controller
 
                 $charge = $openpay->charges->create($chargeRequest);
                 $sale->openpay_transaction_id = $charge->id;
-                $sale->cash_reference = $charge->payment_method->reference ?? null;
-                $sale->cash_barcode_url = $charge->payment_method->barcode_url ?? null;
-                $sale->cash_due_date = Carbon::now()->addHours(24);
+                $cashData = [
+                    'cash_reference'   => $charge->payment_method->reference ?? null,
+                    'cash_barcode_url' => $charge->payment_method->barcode_url ?? null,
+                    'cash_due_date'    => Carbon::now()->addHours(24),
+                ];
             }
 
             $sale->status = $sale->payment_method === 'card' ? ArtistSale::PAYMENT_STATUS_COMPLETED : ArtistSale::PAYMENT_STATUS_PENDING;
             $sale->approval_status = ArtistSale::APPROVAL_STATUS_ACCEPTED;
             $sale->approval_responded_at = Carbon::now();
             $sale->save();
+
+            if ($sale->payment_method === 'cash' && isset($cashData)) {
+                ArtistSaleCashReference::updateOrCreate(
+                    ['artist_sale_id' => $sale->id],
+                    $cashData
+                );
+            }
 
             $this->sendClientNotification($sale, ArtistSale::APPROVAL_STATUS_ACCEPTED);
 

--- a/app/Http/Controllers/Client/ShoppingCart/ShoppingCardController.php
+++ b/app/Http/Controllers/Client/ShoppingCart/ShoppingCardController.php
@@ -267,9 +267,25 @@ class ShoppingCardController extends Controller
             $user_id = $auth_user->id;
 
             $purchases = ArtistSale::where('customer_id', $user_id)
-                ->with('artist', 'artist.manager', 'customer')
+                ->with('artist', 'artist.manager', 'customer', 'cashReference')
                 ->orderBy('created_at', 'desc')
                 ->get();
+
+            $purchases->each(function (ArtistSale $purchase) {
+                if (!$purchase->cashReference) {
+                    return;
+                }
+
+                $cashReference = $purchase->cashReference->cash_reference;
+                if (preg_match('/^LOCAL-(\d+)$/', (string) $cashReference, $matches)) {
+                    $cashReference = '1000' . str_pad($matches[1], 12, '0', STR_PAD_LEFT);
+                }
+
+                $purchase->setAttribute('cash_reference', $cashReference);
+                $purchase->setAttribute('cash_barcode_url', $purchase->cashReference->cash_barcode_url);
+                $purchase->setAttribute('cash_due_date', $purchase->cashReference->cash_due_date);
+                $purchase->unsetRelation('cashReference');
+            });
 
             return response()->json([
                 'success' => true,

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -15,6 +15,7 @@ use Openpay\Data\OpenpayApiConnectionError;
 use Openpay\Data\OpenpayApiTransactionError;
 use Illuminate\Http\JsonResponse;
 use App\Models\ArtistSale;
+use App\Models\ArtistSaleCashReference;
 use App\Models\Artist;
 use App\Models\ShoppingCard;
 use App\Models\ShoppingCardDetail;
@@ -981,10 +982,16 @@ class PaymentController extends Controller
             $dueDateStr = $dueDateInstance->toDateTimeString();
 
             $sale->openpay_transaction_id = $charge->id;
-            $sale->cash_reference = $cashRef;
-            $sale->cash_barcode_url = $barcodeUrl;
-            $sale->cash_due_date = $dueDateInstance;
             $sale->save();
+
+            ArtistSaleCashReference::updateOrCreate(
+                ['artist_sale_id' => $sale->id],
+                [
+                    'cash_reference'   => $cashRef,
+                    'cash_barcode_url' => $barcodeUrl,
+                    'cash_due_date'    => $dueDateInstance,
+                ]
+            );
 
             return response()->json([
                 'data' => [

--- a/app/Models/ArtistSale.php
+++ b/app/Models/ArtistSale.php
@@ -43,9 +43,6 @@ class ArtistSale extends Model
         'event_hours',
         'event_status',
         'openpay_transaction_id',
-        'cash_reference',
-        'cash_barcode_url',
-        'cash_due_date',
         'payment_method',
         'store',
         'latitude',
@@ -58,6 +55,11 @@ class ArtistSale extends Model
         'approval_responded_at',
         'openpay_customer_id',
     ];
+
+    public function cashReference()
+    {
+        return $this->hasOne(ArtistSaleCashReference::class);
+    }
 
     public function artist()
     {

--- a/app/Models/ArtistSaleCashReference.php
+++ b/app/Models/ArtistSaleCashReference.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ArtistSaleCashReference extends Model
+{
+    protected $fillable = [
+        'artist_sale_id',
+        'cash_reference',
+        'cash_barcode_url',
+        'cash_due_date',
+    ];
+
+    protected $casts = [
+        'cash_due_date' => 'datetime',
+    ];
+
+    public function artistSale()
+    {
+        return $this->belongsTo(ArtistSale::class);
+    }
+}

--- a/database/migrations/2026_07_14_000001_create_artist_sale_cash_references_table.php
+++ b/database/migrations/2026_07_14_000001_create_artist_sale_cash_references_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('artist_sale_cash_references', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('artist_sale_id')->constrained('artist_sales')->onDelete('cascade');
+            $table->string('cash_reference')->nullable();
+            $table->string('cash_barcode_url')->nullable();
+            $table->timestamp('cash_due_date')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::table('artist_sales', function (Blueprint $table) {
+            $table->dropColumn(['cash_reference', 'cash_barcode_url', 'cash_due_date']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('artist_sales', function (Blueprint $table) {
+            $table->string('cash_reference')->nullable();
+            $table->string('cash_barcode_url')->nullable();
+            $table->timestamp('cash_due_date')->nullable();
+        });
+
+        Schema::dropIfExists('artist_sale_cash_references');
+    }
+};

--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -12,7 +12,6 @@ class ArtistSalesSeeder extends Seeder
 {
     public function run()
     {
-        DB::statement('TRUNCATE TABLE artist_sales RESTART IDENTITY CASCADE;');
         $this->call(ArtistPayoutMethodSeeder::class);
 
         $artistIds = DB::table('artists')->orderBy('id')->pluck('id')->all();
@@ -20,40 +19,44 @@ class ArtistSalesSeeder extends Seeder
             $q->where('slug', User::ROLE_CLIENT);
         })->get()->values();
 
+        if (empty($artistIds) || $customers->isEmpty()) {
+            return;
+        }
+
         $eventHours     = ['08:00', '10:00', '14:00', '16:00', '18:00', '20:00'];
         $amounts        = [6000, 9000, 12000];
         $eventDateOffsets = [-90, -60, -30, -15, 15, 30, 60, 90, 120, 150];
         $createdAtOffsets = [-150, -120, -90, -75, -60, -30, -20, -10];
         $paymentMethods   = ['card', 'cash'];
         $salesPattern = [
-            ['status' => 'completed', 'event_status' => 'completed'], 
-            ['status' => 'completed', 'event_status' => 'pending'],   
-            ['status' => 'pending',   'event_status' => 'pending'], 
+            ['status' => 'completed', 'event_status' => 'completed'],
+            ['status' => 'completed', 'event_status' => 'pending'],
+            ['status' => 'pending',   'event_status' => 'pending'],
         ];
 
-        for ($i = 0; $i < count($artistIds); $i++) {
-            $artistId = $artistIds[$i];
-
+        foreach ($customers as $customerIndex => $customer) {
             for ($j = 0; $j < count($salesPattern); $j++) {
-                $customer      = $customers[array_rand($customers->all())];
+                $artistId = $artistIds[($customerIndex + $j) % count($artistIds)];
                 $statusPattern = $salesPattern[$j];
 
-                $paymentMethod = $paymentMethods[array_rand($paymentMethods)];
+                $paymentMethod = $paymentMethods[($customerIndex + $j) % count($paymentMethods)];
 
-                $amount = $amounts[array_rand($amounts)];
+                $amount = $amounts[($customerIndex + $j) % count($amounts)];
                 $openpayFee = ($paymentMethod === 'card')
                     ? round(($amount * 0.029) * 1.16, 2)
                     : 0.00;
 
-                $eventDate = Carbon::now()->addDays($eventDateOffsets[array_rand($eventDateOffsets)])->format('Y-m-d');
-                $createdAt = Carbon::now()->addDays($createdAtOffsets[array_rand($createdAtOffsets)])->format('Y-m-d H:i:s');
+                $eventDate = Carbon::now()->addDays($eventDateOffsets[($customerIndex + $j) % count($eventDateOffsets)])->format('Y-m-d');
+                $createdAt = Carbon::now()->addDays($createdAtOffsets[($customerIndex + $j) % count($createdAtOffsets)])->format('Y-m-d H:i:s');
 
-                ArtistSale::create([
+                $sale = ArtistSale::create([
                     'artist_id'              => $artistId,
                     'customer_id'            => $customer->id,
                     'amount'                 => $amount,
                     'openpay_fee'            => $openpayFee,
-                    'openpay_transaction_id' => 'trx_test_' . $artistId . '_' . $customer->id . '_' . $j,
+                    'openpay_transaction_id' => $paymentMethod === 'cash' && $statusPattern['status'] === 'pending'
+                        ? null
+                        : 'trx_test_' . $artistId . '_' . $customer->id . '_' . $j,
                     'customer_first_name'    => explode(' ', $customer->name)[0],
                     'customer_last_name'     => explode(' ', $customer->name)[1] ?? 'Usuario',
                     'customer_email'         => $customer->email,
@@ -68,9 +71,22 @@ class ArtistSalesSeeder extends Seeder
                     'payment_method'         => $paymentMethod,
                     'event_status'           => $statusPattern['event_status'],
                     'status'                 => $statusPattern['status'],
+                    'approval_status'        => 'accepted',
                     'created_at'             => $createdAt,
                     'updated_at'             => $createdAt,
                 ]);
+
+                if ($paymentMethod === 'cash') {
+                    $isPending = $statusPattern['status'] === 'pending';
+
+                    $sale->cashReference()->create([
+                        'cash_reference'    => 'REF-' . strtoupper(uniqid()),
+                        'cash_barcode_url'  => 'https://sandbox-dashboard.openpay.mx/barcode/test_' . $sale->id . '.png',
+                        'cash_due_date'     => $isPending
+                            ? Carbon::now()->addDays(3)
+                            : Carbon::parse($createdAt)->addDays(3),
+                    ]);
+                }
             }
         }
     }

--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -29,9 +29,9 @@ class ArtistSalesSeeder extends Seeder
         $createdAtOffsets = [-150, -120, -90, -75, -60, -30, -20, -10];
         $paymentMethods   = ['card', 'cash'];
         $salesPattern = [
-            ['status' => 'completed', 'event_status' => 'completed'],
-            ['status' => 'completed', 'event_status' => 'pending'],
-            ['status' => 'pending',   'event_status' => 'pending'],
+            ['status' => ArtistSale::PAYMENT_STATUS_COMPLETED, 'event_status' => ArtistSale::EVENT_STATUS_COMPLETED],
+            ['status' => ArtistSale::PAYMENT_STATUS_COMPLETED, 'event_status' => ArtistSale::EVENT_STATUS_PENDING],
+            ['status' => ArtistSale::PAYMENT_STATUS_PENDING,   'event_status' => ArtistSale::EVENT_STATUS_PENDING],
         ];
 
         foreach ($customers as $customerIndex => $customer) {
@@ -54,9 +54,7 @@ class ArtistSalesSeeder extends Seeder
                     'customer_id'            => $customer->id,
                     'amount'                 => $amount,
                     'openpay_fee'            => $openpayFee,
-                    'openpay_transaction_id' => $paymentMethod === 'cash' && $statusPattern['status'] === 'pending'
-                        ? null
-                        : 'trx_test_' . $artistId . '_' . $customer->id . '_' . $j,
+                    'openpay_transaction_id' => $paymentMethod === 'cash' && $statusPattern['status'] === ArtistSale::PAYMENT_STATUS_PENDING ? null : 'trx_test_' . $artistId . '_' . $customer->id,
                     'customer_first_name'    => explode(' ', $customer->name)[0],
                     'customer_last_name'     => explode(' ', $customer->name)[1] ?? 'Usuario',
                     'customer_email'         => $customer->email,
@@ -71,13 +69,13 @@ class ArtistSalesSeeder extends Seeder
                     'payment_method'         => $paymentMethod,
                     'event_status'           => $statusPattern['event_status'],
                     'status'                 => $statusPattern['status'],
-                    'approval_status'        => 'accepted',
+                    'approval_status'        => ArtistSale::APPROVAL_STATUS_ACCEPTED, // --- CONSTANTE AQUÍ TAMBIÉN ---
                     'created_at'             => $createdAt,
                     'updated_at'             => $createdAt,
                 ]);
 
                 if ($paymentMethod === 'cash') {
-                    $isPending = $statusPattern['status'] === 'pending';
+                    $isPending = $statusPattern['status'] === ArtistSale::PAYMENT_STATUS_PENDING;
 
                     $sale->cashReference()->create([
                         'cash_reference'    => 'REF-' . strtoupper(uniqid()),

--- a/database/seeders/OfferSeeder.php
+++ b/database/seeders/OfferSeeder.php
@@ -11,7 +11,9 @@ class OfferSeeder extends Seeder
 {
     public function run()
     {
-        DB::statement('TRUNCATE TABLE offers RESTART IDENTITY CASCADE;');
+        DB::statement("UPDATE artist_sales SET offer_id = NULL WHERE offer_id IS NOT NULL;");
+        DB::statement('DELETE FROM offers;');
+        DB::statement("ALTER SEQUENCE offers_id_seq RESTART WITH 1;");
 
         $artistIds = DB::table('artists')->orderBy('id')->limit(7)->pluck('id')->all();
 

--- a/database/seeders/ShoppingCardDetailsSeeder.php
+++ b/database/seeders/ShoppingCardDetailsSeeder.php
@@ -13,7 +13,7 @@ class ShoppingCardDetailsSeeder extends Seeder
     public function run()
     {
         $client = User::whereHas('roles', function ($q) {
-            $q->where('slug', 'cliente');
+            $q->where('slug', User::ROLE_CLIENT);
         })->first();
 
         if (!$client) {
@@ -23,11 +23,11 @@ class ShoppingCardDetailsSeeder extends Seeder
         $userId = $client->id;
 
         $shoppingCard = ShoppingCard::create([
-            'user_id'           => $userId,
-            'status'            => 1,
+            'user_id' => $userId,
+            'status' => 1,
             'order_date_start'  => now(),
             'order_date_finish' => now()->addDays(7),
-            'total'             => 0,
+            'total' => 0,
         ]);
 
         $artistIds = DB::table('artists')->orderBy('id')->pluck('id')->values();

--- a/database/seeders/ShoppingCardDetailsSeeder.php
+++ b/database/seeders/ShoppingCardDetailsSeeder.php
@@ -5,79 +5,53 @@ namespace Database\Seeders;
 use Illuminate\Database\Seeder;
 use App\Models\ShoppingCard;
 use App\Models\ShoppingCardDetail;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
 
 class ShoppingCardDetailsSeeder extends Seeder
 {
     public function run()
     {
-        DB::statement('TRUNCATE TABLE shoppings_cards_details, shoppings_cards RESTART IDENTITY CASCADE;');
+        $client = User::whereHas('roles', function ($q) {
+            $q->where('slug', 'cliente');
+        })->first();
+
+        if (!$client) {
+            return;
+        }
+
+        $userId = $client->id;
 
         $shoppingCard = ShoppingCard::create([
-            'user_id' => 18,
-            'status' => 1,
-            'order_date_start' => now(),
+            'user_id'           => $userId,
+            'status'            => 1,
+            'order_date_start'  => now(),
             'order_date_finish' => now()->addDays(7),
-            'total' => 0,
+            'total'             => 0,
         ]);
-        $shoppingCardDetails = [
-            [
-                'shopping_card_id' => 1,
-                'artist_id' => 6,
-                'hours' => 2,
-                'price' => 6000,
-            ],
-            [
-                'artist_id' => 3,
-                'hours' => 2,
-                'price' => 15000,
-            ],
-        ];
-        $total = 0;
 
+        $artistIds = DB::table('artists')->orderBy('id')->pluck('id')->values();
+
+        if ($artistIds->count() < 2) {
+            return;
+        }
+
+        $shoppingCardDetails = [
+            ['artist_id' => $artistIds[0], 'hours' => 2, 'price' => 6000],
+            ['artist_id' => $artistIds[1], 'hours' => 2, 'price' => 15000],
+        ];
+
+        $total = 0;
         foreach ($shoppingCardDetails as $detail) {
-            $shoppingCardDetail = ShoppingCardDetail::create([
+            $item = ShoppingCardDetail::create([
                 'shopping_card_id' => $shoppingCard->id,
                 'artist_id' => $detail['artist_id'],
                 'hours' => $detail['hours'],
                 'price' => $detail['price'],
             ]);
-            $total += $shoppingCardDetail->hours * $shoppingCardDetail->price;
+            $total += $item->hours * $item->price;
         }
 
-        $shoppingCard->update(['total' => $total]);
-        $shoppingCard = ShoppingCard::create([
-            'user_id' => 18,
-            'status' => 1,
-            'order_date_start' => '2023-11-02 20:59:47',
-            'order_date_finish' => '2023-11-07 20:59:47',
-            'total' => 0,
-        ]);
-        $shoppingCardDetails = [
-            [
-                'shopping_card_id' => 2,
-                'artist_id' => 6,
-                'hours' => 2,
-                'price' => 6000,
-            ],
-            [
-                'artist_id' => 3,
-                'hours' => 5,
-                'price' => 15000,
-            ],
-        ];
-
-        $total = 0;
-
-        foreach ($shoppingCardDetails as $detail) {
-            $shoppingCardDetail = ShoppingCardDetail::create([
-                'shopping_card_id' => $shoppingCard->id,
-                'artist_id' => $detail['artist_id'],
-                'hours' => $detail['hours'],
-                'price' => $detail['price'],
-            ]);
-            $total += $shoppingCardDetail->hours * $shoppingCardDetail->price;
-        }
         $shoppingCard->update(['total' => $total]);
     }
 }


### PR DESCRIPTION
## 📝 Description
This Pull Request migrates the Openpay cash reference fields (`cash_reference`, `cash_barcode_url`, and `cash_due_date`) out of the main `artist_sales` table and into an isolated, dedicated relation: `ArtistSaleCashReference`. This normalizes the database structure and cleans up the main sale model.

---

## 🚀 Key Changes & Architecture

### 🗄️ Database & Models
- **`2026_07_14_000001_create_artist_sale_cash_references_table.php`**: Created migration for the new `artist_sale_cash_references` table.
- **`ArtistSaleCashReference.php`**: Added the new model supporting the one-to-one relationship.
- **`ArtistSale.php`**: Removed old direct column definitions from `$fillable` and declared the `hasOne(ArtistSaleCashReference)` relation.

### ⚙️ Controllers
- **`ApprovalController` & `PaymentController`**: Refactored to write references through `ArtistSaleCashReference::updateOrCreate` instead of saving columns directly to the sale.
- **`ShoppingCardController`**: Updated the endpoint that returns user purchases. It loads the `cashReference` relation, formats the cash reference code if it has a local prefix (ensuring compatibility with standard barcodes), dynamically injects the values back as model attributes for frontend compatibility, and unsets the relation before responding.

### 🌱 Seeders Robustness
- **`ArtistSalesSeeder`, `OfferSeeder`, `ShoppingCardDetailsSeeder`**: Cleaned up truncated sequences and hardcoded IDs. Refactored seeders to use real database records instead of static user IDs (e.g. ID `18`) to prevent foreign key constraint violations during a clean database migration and seed.