### PR TITLE
Tie cash due date to event date and add warning alert to email

### DIFF
--- a/app/Http/Controllers/Artist/ApprovalController.php
+++ b/app/Http/Controllers/Artist/ApprovalController.php
@@ -127,7 +127,7 @@ class ApprovalController extends Controller
                     'currency'    => 'MXN',
                     'description' => 'Reserva artista - Pago en efectivo',
                     'customer'    => $customerData,
-                    'due_date'    => Carbon::now()->addHours(24)->format('Y-m-d\TH:i:s'),
+                    'due_date'    => $eventDate = Carbon::parse($sale->event_date)->format('Y-m-d\TH:i:s'),
                 ];
 
                 $charge = $openpay->charges->create($chargeRequest);
@@ -135,7 +135,7 @@ class ApprovalController extends Controller
                 $cashData = [
                     'cash_reference'   => $charge->payment_method->reference ?? null,
                     'cash_barcode_url' => $charge->payment_method->barcode_url ?? null,
-                    'cash_due_date'    => Carbon::now()->addHours(24),
+                    'cash_due_date'    => $charge->due_date ?? Carbon::now()->addHours(24),
                 ];
             }
 

--- a/database/migrations/2026_07_09_215613_allow_null_openpay_transaction_id_for_pending_cash_sales.php
+++ b/database/migrations/2026_07_09_215613_allow_null_openpay_transaction_id_for_pending_cash_sales.php
@@ -12,6 +12,10 @@ return new class extends Migration
 
     public function down(): void
     {
+        DB::table('artist_sales')
+            ->whereNull('openpay_transaction_id')
+            ->update(['openpay_transaction_id' => 'rollback-default-value']); 
+
         DB::statement('ALTER TABLE artist_sales ALTER COLUMN openpay_transaction_id SET NOT NULL');
     }
 };

--- a/resources/views/emails/artist-approval-notification.blade.php
+++ b/resources/views/emails/artist-approval-notification.blade.php
@@ -64,6 +64,10 @@
                                                 <span class="info-label">Pagar antes de</span>
                                                 <span class="info-value">{{ Carbon::parse($sale->cash_due_date)->locale('es')->isoFormat('D [de] MMMM, HH:mm') }}</span>
                                             </div>
+                                            <div class="info-row" style="background-color: #fff3cd; padding: 12px; border-radius: 8px; border-left: 4px solid #ff9800; margin-top: 12px;">
+                                                <span class="info-label">⚠️ Recordatorio</span>
+                                                <span class="info-value" style="color: #d32f2f; font-weight: 600;">Completa el pago antes de la fecha del evento: {{ Carbon::parse($sale->event_date)->locale('es')->isoFormat('D [de] MMMM, YYYY [a las] HH:mm') }}</span>
+                                            </div>
                                             @if ($sale->cash_barcode_url)
                                                 <div class="info-row" style="border-bottom: none; justify-content: center;">
                                                     <img src="{{ $sale->cash_barcode_url }}" alt="Código de barras" style="max-width: 260px; height: 80px; object-fit: contain;">


### PR DESCRIPTION
## 📝 Description
This PR addresses critical payment flow logic for cash transactions, ensuring payment deadlines are tied directly to the date of the event. It also adds safety fallbacks to our migration rollbacks and visually improves client notifications.

---

## 🚀 Key Changes & Architecture

### ⚙️ Logic & Business Rules
- **`ApprovalController.php`**: Changed the Openpay cash charge creation to set `due_date` exactly to the event's date (`$sale->event_date`) instead of hardcoding a 24-hour window. The database save fallback also respects Openpay's returned expiration.

### 🗄️ Database Migrations Robustness
- **`2026_07_09_215613_allow_null_openpay_transaction_id_for_pending_cash_sales.php`**: Enhanced the `down()` rollback method. Before altering the column to `NOT NULL` (which would crash if null rows exist), it runs a pre-update query setting a fallback string (`rollback-default-value`) to preserve database integrity.

### 📧 Notifications
- **`artist-approval-notification.blade.php`**: Injected a warning card component alerting clients that they must physically complete their cash payment before the actual start time of the event.