### PR TITLE
update user registration to store default gravatar using spatie media…

### DIFF
--- a/app/Http/Controllers/UserApiController.php
+++ b/app/Http/Controllers/UserApiController.php
@@ -80,9 +80,10 @@ class UserApiController extends Controller
             $user->name = $name;
             $user->email = $email;
             $user->password = bcrypt($password);
-            $user->image_profile = 'https://secure.gravatar.com/avatar/' . $hash . '?s=800&d=retro';
             $user->save();
             $user->roles()->attach($role->id);
+            $absoluteImageUrl = 'https://secure.gravatar.com/avatar/' . $hash . '?s=800&d=retro';
+            $user->addMediaFromUrl($absoluteImageUrl)->toMediaCollection('profile_images');
             DB::commit();
 
             return response()->json([


### PR DESCRIPTION
## Summary

### Refactored User Profile Image Handling

- Updated the user registration flow to stop storing the Gravatar URL directly in the `image_profile` database field.
- Generated the default Gravatar URL after the user is created and saved.
- Integrated **Spatie Media Library** by importing the default profile image from the generated Gravatar URL using `addMediaFromUrl()`.
- Stored the imported image in the `profile_images` media collection, aligning profile image management with the application's media collection architecture.
- Improved consistency by migrating profile image storage from a plain URL field to a centralized media collection managed by Spatie.