### PR TITLE
Calculate net payout for liquidated sales deducting openpay and system fees

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -686,8 +686,11 @@ class PaymentController extends Controller
                 ], 404);
             }
 
-            $salesQuery = ArtistSale::where('artist_id', $artist->id)->where('status', ArtistSale::PAYMENT_STATUS_COMPLETED);
-            $total = (float) $salesQuery->sum('amount');
+            $salesQuery = ArtistSale::where('artist_id', $artist->id)->where('status', ArtistSale::PAYMENT_STATUS_LIQUIDATED);
+            $total = $salesQuery->get()->sum(function($sale) {
+                $netPayout = floatval($sale->amount) - floatval($sale->openpay_fee) - (floatval($sale->amount) * 0.10);
+                return max(0, $netPayout);
+            });
             $count = (clone $salesQuery)->count();
 
             return response()->json([


### PR DESCRIPTION
## 📝 Description
This PR updates the payment controller to calculate the artist's total balance based exclusively on liquidated sales instead of completed ones, applying the corresponding Openpay and system platform fee deductions.

---

## 🚀 Key Changes & Architecture

### ⚙️ Financial & Logic Adjustments
- **Query Update**: Switched the source status from `PAYMENT_STATUS_COMPLETED` to `PAYMENT_STATUS_LIQUIDATED` to ensure we only sum payouts that have gone through the platform's settlement process.
- **Dynamic Fee Deductions**: Replaced the direct flat database `sum('amount')` with an in-memory collection mapping deduction logic:
  - Subtracts the specific Openpay gateway transaction fee (`openpay_fee`).
  - Subtracts the standard $10\%$ platform service commission fee (`amount * 0.10`).
  - Implements a safeguard (`max(0, $netPayout)`) to ensure the calculated balance never results in a negative value.