### PR TITLE
Feature: Add artist event reminder emails and redesign password reset email

### DIFF
--- a/app/Console/Commands/SendEventReminders.php
+++ b/app/Console/Commands/SendEventReminders.php
@@ -42,7 +42,8 @@ class SendEventReminders extends Command
                 }
 
                 Mail::to($artistUser->email)->send(new EventReminderNotification($sale));
-                $sale->update(['reminder_sent_at' => now()]);
+                $sale->reminder_sent_at = now();
+                $sale->save();
                 $count++;
 
                 Log::info('Recordatorio enviado al artista', [

--- a/app/Console/Commands/SendEventReminders.php
+++ b/app/Console/Commands/SendEventReminders.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ArtistSale;
+use App\Mail\EventReminderNotification;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Carbon\Carbon;
+
+class SendEventReminders extends Command
+{
+    protected $signature = 'events:send-reminders';
+    protected $description = 'Envía recordatorio al artista 24h antes del evento';
+
+    public function handle()
+    {
+        $tomorrow = Carbon::tomorrow()->toDateString();
+
+        $events = ArtistSale::whereDate('event_date', $tomorrow)
+            ->where('event_status', ArtistSale::EVENT_STATUS_PENDING)
+            ->where('approval_status', ArtistSale::APPROVAL_STATUS_ACCEPTED)
+            ->where('status', ArtistSale::PAYMENT_STATUS_COMPLETED)
+            ->whereNull('reminder_sent_at')
+            ->get();
+
+        $count = 0;
+
+        foreach ($events as $sale) {
+            try {
+                $artist = $sale->artist;
+                if (!$artist) {
+                    Log::warning('Recordatorio: artista no encontrado', ['sale_id' => $sale->id]);
+                    continue;
+                }
+
+                $artistUser = $artist->user;
+                if (!$artistUser || !$artistUser->email) {
+                    Log::warning('Recordatorio: email de artista no encontrado', ['sale_id' => $sale->id, 'artist_id' => $artist->id]);
+                    continue;
+                }
+
+                Mail::to($artistUser->email)->send(new EventReminderNotification($sale));
+                $sale->update(['reminder_sent_at' => now()]);
+                $count++;
+
+                Log::info('Recordatorio enviado al artista', [
+                    'sale_id' => $sale->id,
+                    'artist' => $artistUser->email,
+                    'event_date' => $sale->event_date,
+                ]);
+            } catch (\Exception $e) {
+                Log::error('Error enviando recordatorio', [
+                    'sale_id' => $sale->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        $this->info("Recordatorios enviados: {$count}");
+    }
+}

--- a/app/Mail/EventReminderNotification.php
+++ b/app/Mail/EventReminderNotification.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\ArtistSale;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class EventReminderNotification extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $sale;
+    public $frontendUrl;
+
+    public function __construct(ArtistSale $sale)
+    {
+        $this->sale = $sale;
+        $this->frontendUrl = config('app.frontend_url');
+    }
+
+    public function build()
+    {
+        return $this->view('emails.event-reminder')
+                    ->subject('Recordatorio de evento - Vibeer');
+    }
+}

--- a/app/Models/ArtistSale.php
+++ b/app/Models/ArtistSale.php
@@ -53,6 +53,7 @@ class ArtistSale extends Model
         'google_place_id',
         'extra_km_distance',
         'extra_km_cost',
+        'reminder_sent_at',
         'approval_status',
         'approval_deadline',
         'approval_responded_at',

--- a/app/Models/ArtistSale.php
+++ b/app/Models/ArtistSale.php
@@ -53,7 +53,6 @@ class ArtistSale extends Model
         'google_place_id',
         'extra_km_distance',
         'extra_km_cost',
-        'reminder_sent_at',
         'approval_status',
         'approval_deadline',
         'approval_responded_at',

--- a/app/Notifications/ResetPasswordQueuedNotification.php
+++ b/app/Notifications/ResetPasswordQueuedNotification.php
@@ -26,13 +26,14 @@ class ResetPasswordQueuedNotification extends Notification
             'email' => $notifiable->email,
         ], true);
 
+        $appUrl = env('FRONTEND_APP');
+
         return (new MailMessage)
             ->subject('Recuperación de contraseña')
-            ->greeting('¡Hola!')
-            ->line('Recibimos una solicitud para restablecer tu contraseña de Vibeer.')
-            ->action('Cambiar contraseña', $resetUrl)
-            ->line('Este enlace expirará en 60 minutos.')
-            ->line('Si no realizaste esta solicitud, puedes ignorar este correo.')
-            ->salutation('Saludos, Vibeer');
+            ->view('emails.password-reset', [
+                'resetUrl' => $resetUrl,
+                'user' => $notifiable,
+                'frontendUrl' => $appUrl,
+            ]);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -26,6 +26,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->resolving(Schedule::class, function (Schedule $schedule) {
             $schedule->command('approvals:expire')->hourly();
+            $schedule->command('events:send-reminders')->hourly();
         });
     }
 }

--- a/database/migrations/2026_07_16_140000_add_reminder_sent_at_to_artist_sales_table.php
+++ b/database/migrations/2026_07_16_140000_add_reminder_sent_at_to_artist_sales_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class AddReminderSentAtToArtistSalesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('artist_sales', function (Blueprint $table) {
+            $table->timestamp('reminder_sent_at')->nullable()->after('event_hours');
+        });
+    }
+
+    public function down()
+    {
+        DB::statement('ALTER TABLE artist_sales DROP COLUMN IF EXISTS reminder_sent_at CASCADE');
+    }
+}

--- a/resources/views/emails/event-reminder.blade.php
+++ b/resources/views/emails/event-reminder.blade.php
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="es">
+@php use Carbon\Carbon; @endphp
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Recordatorio de evento</title>
+    <style>
+        {{ file_get_contents(resource_path('css/app.css')) }}
+        .info-grid { width: 100%; }
+        .info-row { padding: 8px 0; border-bottom: 1px solid #eaeaea; display: flex; align-items: center; }
+        .info-row:last-child { border-bottom: none; }
+        .info-label { width: 100px; font-weight: 700; color: var(--gsm-dark); font-size: 13px; flex-shrink: 0; }
+        .info-value { color: var(--gsm-text); font-size: 14px; }
+        .btn { display: inline-block; padding: 12px 32px; border-radius: 6px; text-decoration: none; font-weight: 700; font-size: 15px; text-align: center; }
+        .btn-primary { background: #094FAB; color: #fff !important; }
+        .link { color: #094FAB; text-decoration: none; font-weight: 600; }
+        .link:hover { text-decoration: underline; }
+        .highlight { background: #fff8e1; border-left: 4px solid #f9a825; padding: 12px 16px; margin: 16px 0; border-radius: 4px; font-size: 14px; color: #5d4037; }
+    </style>
+</head>
+<body>
+    <table class="newsletter-shell" role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+        <tr>
+            <td align="center" class="newsletter-shell__outer">
+                <table class="newsletter-card" role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                    <tr>
+                        <td class="newsletter-hero">
+                            <img src="{{ $message->embed(public_path('logovibeer.png')) }}" alt="Vibeer" class="newsletter-logo">
+                            <h1 class="newsletter-title" style="margin-top: 12px;">Recordatorio de evento</h1>
+                            <p style="font-size: 16px; margin-bottom: 4px;">Hola {{ $sale->artist->name ?? 'artista' }},</p>
+                            <p class="newsletter-subtitle">Tienes un evento programado para ma&ntilde;ana. Aqu&iacute; est&aacute;n los detalles:</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="newsletter-content">
+                            <div class="newsletter-body">
+                                <div class="highlight">
+                                    <strong>Recuerda:</strong> Este evento comienza en menos de 24 horas. Aseg&uacute;rate de llegar puntual.
+                                </div>
+
+                                <div class="info-grid">
+                                    <div class="info-row">
+                                        <span class="info-label">Cliente</span>
+                                        <span class="info-value">{{ $sale->customer_first_name }} {{ $sale->customer_last_name }}</span>
+                                    </div>
+                                    <div class="info-row">
+                                        <span class="info-label">Fecha</span>
+                                        <span class="info-value">{{ Carbon::parse($sale->event_date)->locale('es')->isoFormat('dddd D [de] MMMM [de] YYYY') }}</span>
+                                    </div>
+                                    <div class="info-row">
+                                        <span class="info-label">Horario</span>
+                                        <span class="info-value">{{ $sale->event_hour }} &middot; {{ $sale->event_hours }} hora(s)</span>
+                                    </div>
+                                    <div class="info-row">
+                                        <span class="info-label">Ubicaci&oacute;n</span>
+                                        <span class="info-value">
+                                            <a href="https://www.google.com/maps?q={{ urlencode($sale->customer_address . ($sale->customer_city ? ', ' . $sale->customer_city : '') . ($sale->customer_state ? ', ' . $sale->customer_state : '')) }}" target="_blank" class="link">
+                                                {{ $sale->customer_address }}{{ $sale->customer_city ? ', ' . $sale->customer_city : '' }}{{ $sale->customer_state ? ', ' . $sale->customer_state : '' }}
+                                            </a>
+                                        </span>
+                                    </div>
+                                </div>
+
+                                <div style="margin-top: 28px; text-align: center;">
+                                    <a href="{{ $frontendUrl }}/artist/my-calendar" target="_blank" class="btn btn-primary" style="color: #fff; background: #094FAB;">
+                                        Ver mi calendario
+                                    </a>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="newsletter-footer">
+                            <p>Recibiste este correo porque tienes un evento programado en Vibeer.</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/resources/views/emails/password-reset.blade.php
+++ b/resources/views/emails/password-reset.blade.php
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Recuperación de contraseña</title>
+    <style>
+        {{ file_get_contents(resource_path('css/app.css')) }}
+        .btn { display: inline-block; padding: 12px 32px; border-radius: 6px; text-decoration: none; font-weight: 700; font-size: 15px; text-align: center; }
+        .btn-primary { background: #094FAB; color: #fff !important; }
+        .info-grid { width: 100%; }
+        .info-row { padding: 8px 0; display: flex; align-items: center; justify-content: center; }
+        .info-label { font-weight: 700; color: var(--gsm-dark); font-size: 13px; }
+        .warning-text { color: #dc3545; font-size: 13px; text-align: center; margin-top: 16px; }
+        .expiry-text { color: #666; font-size: 13px; text-align: center; margin-top: 8px; }
+    </style>
+</head>
+<body>
+    <table class="newsletter-shell" role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+        <tr>
+            <td align="center" class="newsletter-shell__outer">
+                <table class="newsletter-card" role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                    <tr>
+                        <td class="newsletter-hero">
+                            <img src="{{ $message->embed(public_path('logovibeer.png')) }}" alt="Vibeer" class="newsletter-logo">
+                            <h1 class="newsletter-title" style="margin-top: 12px;">Recuperaci&oacute;n de contrase&ntilde;a</h1>
+                            <p class="newsletter-subtitle">Hola {{ $user->name ?? 'usuario' }}, recibimos una solicitud para restablecer tu contrase&ntilde;a.</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="newsletter-content">
+                            <div class="newsletter-body">
+                                <div class="info-grid">
+                                    <div class="info-row">
+                                        <span class="info-label">Para continuar, haz clic en el siguiente bot&oacute;n:</span>
+                                    </div>
+                                </div>
+
+                                <div style="margin-top: 28px; text-align: center;">
+                                    <a href="{{ $resetUrl }}" target="_blank" class="btn btn-primary" style="color: #fff; background: #094FAB;">
+                                        Cambiar contrase&ntilde;a
+                                    </a>
+                                </div>
+
+                                <p style="text-align: center; color: #666; font-size: 13px; margin-top: 8px;">
+                                    Este enlace expirar&aacute; en <strong>60 minutos</strong>.
+                                </p>
+
+                                <p class="warning-text">
+                                    Si no realizaste esta solicitud, puedes ignorar este correo.
+                                </p>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="newsletter-footer">
+                            <p>Recibiste este correo porque solicitaste restablecer tu contrase&ntilde;a en Vibeer.</p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
**Summary**

This PR enhances the email notification system by introducing automatic reminder emails for artists 24 hours before their scheduled events and redesigning the password reset email template.

A scheduled command was added to send reminders only once per event, while the password recovery notification now uses an updated email template for a more polished and consistent user experience.

**Changes Implemented**

🔹 Event Reminder Notifications

- Added automatic reminder emails sent to artists 24 hours before their scheduled event.
- Implemented a scheduled command to process pending reminders.
- Added tracking to ensure each reminder is sent only once.
- Created a dedicated email template for event reminders.

🔹 Password Recovery Email

- Redesigned the password reset email template.
- Updated the queued password reset notification to use the new design.
- Improved the visual consistency of authentication emails.

🔹 Application Configuration

- Registered the reminder functionality within the application.
- Extended the event model to support reminder tracking.

**📁 Files Modified**

Backend

Console

- app/Console/Commands/SendEventReminders.php

Models

- app/Models/ArtistSale.php

Notifications

- app/Notifications/ResetPasswordQueuedNotification.php

Mail

- app/Mail/EventReminderNotification.php

Providers

- app/Providers/AppServiceProvider.php

Migrations

- database/migrations/2026_07_16_140000_add_reminder_sent_at_to_artist_sales_table.php

Email Views

- resources/views/emails/event-reminder.blade.php
- resources/views/emails/password-reset.blade.php