### PR TITLE
Implement artist profile approval workflow

### DIFF
--- a/app/Http/Controllers/Admin/ArtistApprovalController.php
+++ b/app/Http/Controllers/Admin/ArtistApprovalController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Artist;
+use App\Models\ArtistProfileRequest;
+use App\Models\Manager;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class ArtistApprovalController extends Controller
+{
+    public function pendingRequests()
+    {
+        try {
+            $pending = ArtistProfileRequest::where('approval_status', ArtistProfileRequest::APPROVAL_STATUS_PENDING)
+                ->with(['user', 'artist.manager', 'artist.musicalGenders'])
+                ->oldest()
+                ->get();
+
+            return response()->json(['success' => true, 'requests' => $pending]);
+        } catch (\Exception $e) {
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
+    }
+
+    public function accept($id)
+    {
+        try {
+            $profileRequest = ArtistProfileRequest::where('id', $id)
+                ->where('approval_status', ArtistProfileRequest::APPROVAL_STATUS_PENDING)
+                ->first();
+
+            if (!$profileRequest) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Esta solicitud ya no está pendiente (puede que ya se haya revisado). Actualiza la lista.',
+                ], 404);
+            }
+
+            $data = $profileRequest->proposed_data;
+
+            DB::beginTransaction();
+
+            $artist = $profileRequest->request_type === ArtistProfileRequest::TYPE_CREATION
+                ? new Artist(['user_id' => $profileRequest->user_id])
+                : Artist::findOrFail($profileRequest->artist_id);
+
+            $artist->name = $data['name'];
+            $artist->slug = Str::slug($data['name']);
+            $artist->members = $data['members'];
+            $artist->history = $data['history'];
+            $artist->zone = $data['zone'];
+            $artist->price_hour = $data['price_hour'];
+            $artist->extra_kilometre = $data['extra_kilometre'];
+            $artist->coverage_radius = $data['coverage_radius'] ?? 0;
+            $artist->social_media = $data['social_media'] ?? null;
+            $artist->save();
+
+            $pendingArtistImage = $profileRequest->getFirstMedia('pending_artist_image');
+            if ($pendingArtistImage) {
+                $pendingArtistImage->copy($artist, 'artist_image');
+            }
+
+            $manager = $artist->manager ?: new Manager(['artist_id' => $artist->id]);
+            $manager->artist_id = $artist->id;
+            $manager->name = $data['name_manager'];
+            $manager->phone = $data['phone_manager'];
+            $manager->email = $data['email_manager'];
+            $manager->save();
+
+            $pendingManagerImage = $profileRequest->getFirstMedia('pending_manager_image');
+            if ($pendingManagerImage) {
+                $pendingManagerImage->copy($manager, 'manager_image');
+            }
+
+            if (!empty($data['musical_genders'])) {
+                $artist->musicalGenders()->sync($data['musical_genders']);
+            }
+
+            $profileRequest->artist_id = $artist->id;
+            $profileRequest->approval_status = ArtistProfileRequest::APPROVAL_STATUS_ACCEPTED;
+            $profileRequest->reviewed_at = Carbon::now();
+            $profileRequest->authorized_by = Auth::id();
+            $profileRequest->save();
+
+            DB::commit();
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Solicitud aceptada, el artista ya es visible en tienda.',
+            ]);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
+    }
+
+    public function reject(Request $request, $id)
+    {
+        try {
+            $profileRequest = ArtistProfileRequest::where('id', $id)
+                ->where('approval_status', ArtistProfileRequest::APPROVAL_STATUS_PENDING)
+                ->first();
+
+            if (!$profileRequest) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Esta solicitud ya no está pendiente (puede que ya se haya revisado). Actualiza la lista.',
+                ], 404);
+            }
+
+            $profileRequest->approval_status = ArtistProfileRequest::APPROVAL_STATUS_REJECTED;
+            $profileRequest->rejection_reason = $request->input('rejection_reason');
+            $profileRequest->reviewed_at = Carbon::now();
+            $profileRequest->save();
+
+            return response()->json(['success' => true, 'message' => 'Solicitud rechazada.']);
+        } catch (\Exception $e) {
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/Artist/ArtistController.php
+++ b/app/Http/Controllers/Artist/ArtistController.php
@@ -4,12 +4,12 @@ namespace App\Http\Controllers\Artist;
 
 use App\Http\Controllers\Controller;
 use App\Models\Artist;
+use App\Models\ArtistProfileRequest;
 use App\Models\Manager;
 use App\Rules\ValidImageUpload;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use App\Rules\ValidSocialMedia;
 use App\Models\ArtistVideo;
 use Carbon\Carbon;
@@ -27,9 +27,14 @@ class ArtistController extends Controller
         try {
             $artistMusicalGenders = Artist::with('musicalGenders')->with('manager')->where('user_id', Auth::user()->id)->first();
 
+            $latestRequest = ArtistProfileRequest::where('user_id', Auth::user()->id)
+                ->latest()
+                ->first();
+
             return response()->json([
                 'success' => true,
                 'artists' => $artistMusicalGenders,
+                'latestRequest' => $latestRequest,
             ], 200);
         } catch (\Exception $e) {
             return response()->json([
@@ -73,11 +78,22 @@ class ArtistController extends Controller
                 'image_manager'   => ['required', 'file', 'max:20480', new ValidImageUpload()],
             ]);
 
-            DB::beginTransaction();
-            $artist = Artist::create([
-                'user_id' => Auth::user()->id,
+            $existingArtist = Artist::where('user_id', Auth::user()->id)->first();
+            $existingPending = ArtistProfileRequest::where('user_id', Auth::user()->id)
+                ->where('approval_status', ArtistProfileRequest::APPROVAL_STATUS_PENDING)
+                ->exists();
+
+            if ($existingArtist || $existingPending) {
+                return response()->json([
+                    'success' => false,
+                    'message' => $existingPending
+                        ? 'Ya tienes una solicitud en revisión.'
+                        : 'Ya tienes un perfil de artista registrado.',
+                ], 422);
+            }
+
+            $proposedData = [
                 'name' => $request->input('name'),
-                'slug' => Str::slug($request->input('name')),
                 'members' => $request->input('members'),
                 'history' => $request->input('history'),
                 'zone' => $request->input('zone'),
@@ -85,28 +101,33 @@ class ArtistController extends Controller
                 'extra_kilometre' => $request->input('extra_kilometre'),
                 'coverage_radius' => $request->input('coverage_radius', 0),
                 'social_media' => $request->input('social_media') ? json_decode($request->input('social_media'), true) : null,
+                'musical_genders' => json_decode($request->selection, true),
+                'name_manager' => $request->input('name_manager'),
+                'phone_manager' => $request->input('phone_manager'),
+                'email_manager' => $request->input('email_manager'),
+            ];
+
+            DB::beginTransaction();
+            $profileRequest = ArtistProfileRequest::create([
+                'user_id' => Auth::user()->id,
+                'artist_id' => null,
+                'request_type' => ArtistProfileRequest::TYPE_CREATION,
+                'proposed_data' => $proposedData,
             ]);
 
             if ($request->hasFile('image_artist')) {
-                $artist->addMedia($request->file('image_artist'))->toMediaCollection('artist_image');
+                $profileRequest->addMedia($request->file('image_artist'))->toMediaCollection('pending_artist_image');
             }
 
-            $artist->musicalGenders()->sync(json_decode($request->selection));
-            $managerModel = Manager::create([
-                'artist_id' => $artist->id,
-                'name'      => $request->input('name_manager'),
-                'phone'     => $request->input('phone_manager'),
-                'email'     => $request->input('email_manager'),
-            ]);
-
             if ($request->hasFile('image_manager')) {
-                $managerModel->addMedia($request->file('image_manager'))->toMediaCollection('manager_image');
+                $profileRequest->addMedia($request->file('image_manager'))->toMediaCollection('pending_manager_image');
             }
             DB::commit();
 
             return response()->json([
                 'success' => true,
-                'artist'  => $artist,
+                'message' => 'Tu solicitud fue enviada, Vibeer la revisará.',
+                'profileRequest' => $profileRequest,
             ], 200);
         } catch (ValidationException $e) {
             return response()->json([
@@ -244,38 +265,55 @@ class ArtistController extends Controller
                 'social_media' => ['nullable', new ValidSocialMedia()],
             ]);
 
-            DB::beginTransaction();
             $artist = Artist::find($request->id);
 
-            $artist->name = $request->input('name');
-            $artist->slug = Str::slug($request->input('name'));
-            $artist->members = $request->input('members');
-            $artist->history = $request->input('history');
-            $artist->zone = $request->input('zone');
-            $artist->price_hour = $request->input('price_hour');
-            $artist->extra_kilometre = $request->input('extra_kilometre');
-            $artist->coverage_radius = $request->input('coverage_radius', 0);
-            $artist->social_media = $request->input('social_media') ? json_decode($request->input('social_media'), true) : null;
+            $existingPending = ArtistProfileRequest::where('artist_id', $artist->id)
+                ->where('approval_status', ArtistProfileRequest::APPROVAL_STATUS_PENDING)
+                ->exists();
+
+            if ($existingPending) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Tu perfil está en revisión, no puedes editar hasta que sea aprobado.',
+                ], 403);
+            }
+
+            $proposedData = [
+                'name' => $request->input('name'),
+                'members' => $request->input('members'),
+                'history' => $request->input('history'),
+                'zone' => $request->input('zone'),
+                'price_hour' => $request->input('price_hour'),
+                'extra_kilometre' => $request->input('extra_kilometre'),
+                'coverage_radius' => $request->input('coverage_radius', 0),
+                'social_media' => $request->input('social_media') ? json_decode($request->input('social_media'), true) : null,
+                'musical_genders' => json_decode($request->selection, true),
+                'name_manager' => $request->input('name_manager'),
+                'phone_manager' => $request->input('phone_manager'),
+                'email_manager' => $request->input('email_manager'),
+            ];
+
+            DB::beginTransaction();
+            $profileRequest = ArtistProfileRequest::create([
+                'user_id' => Auth::user()->id,
+                'artist_id' => $artist->id,
+                'request_type' => ArtistProfileRequest::TYPE_UPDATE,
+                'proposed_data' => $proposedData,
+            ]);
 
             if ($request->hasFile('image_artist')) {
-                $artist->addMedia($request->file('image_artist'))->toMediaCollection('artist_image');
+                $profileRequest->addMedia($request->file('image_artist'))->toMediaCollection('pending_artist_image');
             }
 
             if ($request->hasFile('image_manager')) {
-                $artist->manager->addMedia($request->file('image_manager'))->toMediaCollection('manager_image');
+                $profileRequest->addMedia($request->file('image_manager'))->toMediaCollection('pending_manager_image');
             }
-
-            $artist->manager->name = $request->input('name_manager');
-            $artist->manager->phone = $request->input('phone_manager');
-            $artist->manager->email = $request->input('email_manager');
-
-            $artist->push();
             DB::commit();
-            $artist->musicalGenders()->sync(json_decode($request->selection));
 
             return response()->json([
                 'success' => true,
-                'artist'  => $artist,
+                'message' => 'Tu solicitud fue enviada, Vibeer la revisará.',
+                'profileRequest' => $profileRequest,
             ], 200);
         } catch (\Illuminate\Validation\ValidationException $e) {
             DB::rollback();
@@ -438,7 +476,6 @@ class ArtistController extends Controller
             ], 401);
         }
     }
-
 
     /**
      * Display a listing of the resource of all Artists with Musical Genders.

--- a/app/Http/Controllers/Artist/ArtistController.php
+++ b/app/Http/Controllers/Artist/ArtistController.php
@@ -27,9 +27,7 @@ class ArtistController extends Controller
         try {
             $artistMusicalGenders = Artist::with('musicalGenders')->with('manager')->where('user_id', Auth::user()->id)->first();
 
-            $latestRequest = ArtistProfileRequest::where('user_id', Auth::user()->id)
-                ->latest()
-                ->first();
+            $latestRequest = ArtistProfileRequest::where('user_id', Auth::user()->id) ->latest() ->first();
 
             return response()->json([
                 'success' => true,

--- a/app/Models/ArtistProfileRequest.php
+++ b/app/Models/ArtistProfileRequest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+
+class ArtistProfileRequest extends Model implements HasMedia
+{
+    use HasFactory, InteractsWithMedia;
+
+    const TYPE_CREATION = 'creation';
+    const TYPE_UPDATE = 'update';
+
+    const APPROVAL_STATUS_PENDING = 'pending_approval';
+    const APPROVAL_STATUS_ACCEPTED = 'accepted';
+    const APPROVAL_STATUS_REJECTED = 'rejected';
+
+    protected $fillable = [
+        'user_id',
+        'artist_id',
+        'request_type',
+        'proposed_data',
+        'approval_status',
+        'rejection_reason',
+        'reviewed_at',
+        'authorized_by',
+    ];
+
+    protected $casts = [
+        'proposed_data' => 'array',
+        'reviewed_at' => 'datetime',
+    ];
+
+    protected $appends = ['image_artist_url', 'image_manager_url'];
+
+    public function getImageArtistUrlAttribute()
+    {
+        return $this->getFirstMediaUrl('pending_artist_image');
+    }
+
+    public function getImageManagerUrlAttribute()
+    {
+        return $this->getFirstMediaUrl('pending_manager_image');
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('pending_artist_image')->singleFile();
+        $this->addMediaCollection('pending_manager_image')->singleFile();
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function artist()
+    {
+        return $this->belongsTo(Artist::class);
+    }
+
+    public function authorizedBy()
+    {
+        return $this->belongsTo(User::class, 'authorized_by');
+    }
+}

--- a/database/migrations/2026_07_20_000000_create_artist_profile_requests_table.php
+++ b/database/migrations/2026_07_20_000000_create_artist_profile_requests_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('artist_profile_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('artist_id')->nullable()->constrained('artists');
+            $table->enum('request_type', ['creation', 'update']);
+            $table->jsonb('proposed_data');
+            $table->enum('approval_status', ['pending_approval', 'accepted', 'rejected'])
+                ->default('pending_approval');
+            $table->text('rejection_reason')->nullable();
+            $table->timestamp('reviewed_at')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP TABLE IF EXISTS artist_profile_requests CASCADE');
+    }
+};

--- a/database/migrations/2026_07_21_000000_add_authorized_by_to_artist_profile_requests_table.php
+++ b/database/migrations/2026_07_21_000000_add_authorized_by_to_artist_profile_requests_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('artist_profile_requests', function (Blueprint $table) {
+            $table->foreignId('authorized_by')
+                ->nullable()
+                ->after('reviewed_at')
+                ->constrained('users')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('artist_profile_requests', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('authorized_by');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,7 @@ use App\Http\Controllers\GoogleMapsController;
 use App\Http\Controllers\SupportTicketController;
 use App\Http\Controllers\ArtistPayoutMethodController;
 use App\Http\Controllers\Admin\AdminPayoutController;
+use App\Http\Controllers\Admin\ArtistApprovalController;
 use App\Http\Controllers\Artist\ApprovalController;
 use App\Http\Controllers\WebhookController;
 
@@ -63,6 +64,9 @@ Route::group(["middleware" => "auth:api"], function () {
     Route::get('/admin/dashboard-overview', [DashboardStatsController::class, 'index']);
     Route::get('/admin/payouts/pending', [AdminPayoutController::class, 'pendingPayouts']);
     Route::post('/admin/payouts/{saleId}/release', [AdminPayoutController::class, 'releasePayout']);
+    Route::get('/admin/artist-approvals/pending', [ArtistApprovalController::class, 'pendingRequests']);
+    Route::put('/admin/artist-approvals/{id}/accept', [ArtistApprovalController::class, 'accept']);
+    Route::put('/admin/artist-approvals/{id}/reject', [ArtistApprovalController::class, 'reject']);
 
     //Route for artist
     Route::post('/artist-new/up-date/{id}', [ArtistController::class, 'updateDetails']);


### PR DESCRIPTION
## 📝 Description
This Pull Request introduces a moderation and approval workflow for artist profile registration and updates. Profile changes made by artists no longer mutate primary tables directly; instead, they generate a pending request for administrator review.

---

## 🔍 Context & Problem
1. **Unmonitored Profile Changes:** Previously, artists could freely create or edit their profile data and media without administrative oversight, posing content quality and security risks.
2. **Data Overwrites:** Updating details directly modified the active profile state, leaving no trail for pending approval states or rejection mechanisms.

---

## 🚀 Key Changes & Architecture

### 🗄️ Database & Models (`ArtistProfileRequest.php`)
- **Schema & Migrations:** Created `artist_profile_requests` table to store proposed modifications, including fields for rejection reasons and the administrator who authorized the request (`authorized_by`).
- **Media Support:** Added support for pending media collections (`pending_artist_image`, `pending_manager_image`).

### 👤 Artist Profile Handling (`ArtistController.php`)
- **Pending Protection:** Updated `store()` and `updateDetails()` to intercept attempts when a request is already in `pending_approval` status, returning a `422/403` validation error.
- **Request Serialization:** Modified responses to include the `latestRequest` relation to communicate the current review state to the client.

### 🛡️ Admin Moderation Workflow (`ArtistApprovalController.php`)
- **Endpoints:** Exposed new administrative routes under `/api/admin/artist-approvals/*` to list pending requests, accept proposals (applying changes to the primary models), or reject them with feedback.

---

## 🧪 Testing Checklist
- [ ] Run `php artisan migrate` to create the `artist_profile_requests` table.
- [ ] Submit a new artist profile or update an existing one using an `artist` role account. Confirm data is routed to `artist_profile_requests` with status `pending_approval`.
- [ ] Log in as an administrator and test accepting and rejecting requests via `/api/admin/artist-approvals/...`.