### PR TITLE
feat(payouts): add payout logs table, model, route and history contro…

### DIFF
--- a/app/Http/Controllers/Admin/AdminPayoutController.php
+++ b/app/Http/Controllers/Admin/AdminPayoutController.php
@@ -5,10 +5,33 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\ArtistSale;
 use App\Models\EventCancellation;
+use App\Models\PayoutLog as PayoutLogModel;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class AdminPayoutController extends Controller
 {
+    private function calculateAdjustedNetPayout(ArtistSale $sale): float
+    {
+        $amount = floatval($sale->amount);
+        $openpayFee = floatval($sale->openpay_fee);
+        $platformFee = $amount * 0.10;
+        $netArtistPayout = $amount - $openpayFee - $platformFee;
+
+        $penalties = EventCancellation::select('event_cancellations.penalty_amount')
+            ->join('artist_sales', 'event_cancellations.artist_sale_id', '=', 'artist_sales.id')
+            ->where('artist_sales.artist_id', $sale->artist_id)
+            ->where('event_cancellations.penalty_paid', false)
+            ->where('event_cancellations.penalty_amount', '>', 0)
+            ->whereNotNull('event_cancellations.penalty_amount')
+            ->get();
+
+        $totalPenalties = $penalties->sum('penalty_amount');
+
+        return max(0, $netArtistPayout - $totalPenalties);
+    }
+
     public function pendingPayouts(): JsonResponse
     {
         $sales = ArtistSale::with(['artist.payoutMethod'])
@@ -117,22 +140,63 @@ class AdminPayoutController extends Controller
             ], 400);
         }
 
-        $sale->status = ArtistSale::PAYMENT_STATUS_LIQUIDATED;
-        $sale->save();
+        $adminId = Auth::id();
 
-        EventCancellation::whereIn('artist_sale_id', function ($query) use ($sale) {
-            $query->select('id')
-                ->from('artist_sales')
-                ->where('artist_id', $sale->artist_id);
-        })
-            ->where('penalty_paid', false)
-            ->where('penalty_amount', '>', 0)
-            ->whereNotNull('penalty_amount')
-            ->update(['penalty_paid' => true]);
+        if (!$adminId) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No se pudo identificar al administrador autenticado.'
+            ], 401);
+        }
+
+        DB::transaction(function () use ($sale, $adminId) {
+            $adjustedNetPayout = $this->calculateAdjustedNetPayout($sale);
+
+            $sale->status = ArtistSale::PAYMENT_STATUS_LIQUIDATED;
+            $sale->save();
+
+            PayoutLogModel::create([
+                'sale_id' => $sale->id,
+                'artist_id' => $sale->artist_id,
+                'user_id' => $adminId,
+                'amount' => $adjustedNetPayout,
+            ]);
+
+            EventCancellation::whereIn('artist_sale_id', function ($query) use ($sale) {
+                $query->select('id')
+                    ->from('artist_sales')
+                    ->where('artist_id', $sale->artist_id);
+            })
+                ->where('penalty_paid', false)
+                ->where('penalty_amount', '>', 0)
+                ->whereNotNull('penalty_amount')
+                ->update(['penalty_paid' => true]);
+        });
 
         return response()->json([
             'success' => true,
             'message' => 'La liquidación ha sido marcada como pagada con éxito.'
+        ], 200);
+    }
+
+    public function payoutHistory(): JsonResponse
+    {
+        $payouts = PayoutLogModel::with(['sale', 'artist', 'administrator'])
+            ->latest()
+            ->get()
+            ->map(function (PayoutLogModel $payout) {
+                return [
+                    'sale_id' => $payout->sale_id,
+                    'artist_name' => $payout->artist ? $payout->artist->name : 'N/A',
+                    'admin_name' => $payout->administrator ? $payout->administrator->name : 'N/A',
+                    'amount' => floatval($payout->amount),
+                    'created_at' => $payout->created_at ? $payout->created_at->toDateTimeString() : null,
+                ];
+            });
+
+        return response()->json([
+            'success' => true,
+            'data' => $payouts,
         ], 200);
     }
 }

--- a/app/Models/PayoutLog.php
+++ b/app/Models/PayoutLog.php
@@ -8,8 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class PayoutLog extends Model
 {
     use HasFactory;
-
-    protected $table = 'payouts_logs';
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    public const TABLE_PAYOUTS_LOGS = 'payouts_logs';
+    protected $table = self::TABLE_PAYOUTS_LOGS;
 
     protected $fillable = [
         'sale_id',

--- a/app/Models/PayoutLog.php
+++ b/app/Models/PayoutLog.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PayoutLog extends Model
+{
+    use HasFactory;
+
+    protected $table = 'payouts_logs';
+
+    protected $fillable = [
+        'sale_id',
+        'artist_id',
+        'user_id',
+        'amount',
+    ];
+
+    public function sale()
+    {
+        return $this->belongsTo(ArtistSale::class, 'sale_id');
+    }
+
+    public function artist()
+    {
+        return $this->belongsTo(Artist::class, 'artist_id');
+    }
+
+    public function administrator()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/database/migrations/2026_07_22_000000_create_payouts_logs_table.php
+++ b/database/migrations/2026_07_22_000000_create_payouts_logs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePayoutsLogsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('payouts_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('sale_id')->constrained('artist_sales')->onDelete('cascade');
+            $table->foreignId('artist_id')->constrained('artists')->onDelete('cascade');
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->decimal('amount', 10, 2);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement('DROP TABLE IF EXISTS payouts_logs CASCADE');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,6 +64,7 @@ Route::group(["middleware" => ["auth:api", CheckAccountStatus::class]], function
     Route::resource('/admin/musical-genders', MusicalsGendersController::class);
     Route::get('/admin/dashboard-overview', [DashboardStatsController::class, 'index']);
     Route::get('/admin/payouts/pending', [AdminPayoutController::class, 'pendingPayouts']);
+    Route::get('/admin/payouts/history', [AdminPayoutController::class, 'payoutHistory']);
     Route::post('/admin/payouts/{saleId}/release', [AdminPayoutController::class, 'releasePayout']);
     Route::get('/admin/user-sanctions', [UserSanctionController::class, 'index']);
     Route::post('/admin/user-sanctions', [UserSanctionController::class, 'store']);


### PR DESCRIPTION
## Summary
Added the database migration, Eloquent model, and API endpoint to log and retrieve the history of released payouts (`payouts_logs`).

## Changes Included
- **Database Migration**: Created `payouts_logs` table with cascade foreign keys (`sale_id`, `artist_id`, `user_id`) and `DROP TABLE IF EXISTS ... CASCADE` in the rollback method.
- **Model**: Created `PayoutLog` model with relational mappings (`sale`, `artist`, and `administrator`).
- **Controller**: Added `payoutHistory()` method in `AdminPayoutController` to retrieve eager-loaded history logs safely.
- **Routing**: Registered the `GET /api/admin/payouts/history` route in `routes/api.php` under protected admin middleware.

## How to Test
1. Run migrations: `php artisan migrate`.
2. Clear route cache: `php artisan route:clear`.
3. Perform a `GET` request to `/api/admin/payouts/history` with an Admin bearer token.
4. Confirm it returns a `200 OK` response with the expected JSON structure containing `payouts_logs` data.