### PR TITLE
enforce accepted status for event sanctions, refactor gallery

### DIFF
--- a/app/Http/Controllers/Admin/UserSanctionController.php
+++ b/app/Http/Controllers/Admin/UserSanctionController.php
@@ -129,6 +129,9 @@ class UserSanctionController extends Controller
 
                 $cancellationsQuery = EventCancellation::where('user_id', $user->id)
                     ->where('created_at', '>=', $thirtyDaysAgo) 
+                    ->whereHas('artistSale', function ($q) {
+                        $q->where('approval_status', ArtistSale::APPROVAL_STATUS_ACCEPTED);
+                    })
                     ->with('artistSale');
                 
                 if (!empty($lastSanction)) {
@@ -224,6 +227,9 @@ class UserSanctionController extends Controller
                 ->get();
 
             $cancellations = EventCancellation::where('user_id', $user->id)
+                ->whereHas('artistSale', function ($q) {
+                    $q->where('approval_status', ArtistSale::APPROVAL_STATUS_ACCEPTED);
+                })
                 ->with('artistSale')
                 ->orderBy('id', 'desc')
                 ->get();
@@ -476,6 +482,14 @@ class UserSanctionController extends Controller
                 ], 404);
             }
             $sale = $cancellation->artistSale;
+
+            if ($sale->approval_status !== ArtistSale::APPROVAL_STATUS_ACCEPTED) {
+                return response()->json([
+                    'success' => true,
+                    'message' => 'El evento no había sido aceptado por el artista. No se aplican sanciones.'
+                ], 200);
+            }
+
             if (empty($sale->event_date)) {
                 return response()->json([
                     'success' => false,
@@ -534,6 +548,9 @@ class UserSanctionController extends Controller
             $cancellationsQuery = EventCancellation::where('user_id', $user->id)
                 ->where('id', '!=', $cancellation->id)
                 ->where('created_at', '>=', $thirtyDaysAgo)
+                ->whereHas('artistSale', function($q) {
+                    $q->where('approval_status', ArtistSale::APPROVAL_STATUS_ACCEPTED);
+                })
                 ->with('artistSale');
             if ($lastSanction) {
                 $cancellationsQuery->where('created_at', '>', $lastSanction->created_at);

--- a/app/Http/Controllers/Artist/ArtistController.php
+++ b/app/Http/Controllers/Artist/ArtistController.php
@@ -457,23 +457,51 @@ class ArtistController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  Request  $request
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int|string|null  $id
      * @return \Illuminate\Http\Response
      */
-    public function deleteGaleryArtist(Request  $request)
+    public function deleteGaleryArtist(Request $request, $id = null)
     {
         try {
             $artist = Artist::where('user_id', Auth::user()->id)->firstOrFail();
 
+            $targetId = $id;
+            if (!$targetId) {
+                $targetId = $request->input('media_id');
+            }
+            if (!$targetId) {
+                $targetId = $request->input('id');
+            }
+            if (!$targetId) {
+                throw new \Exception('Petición rechazada: No se recibió un ID de imagen.');
+            }
+
             DB::beginTransaction();
-            $artist->clearMediaCollection('artist_gallery');
+
+            if ($targetId !== 'Yes' && !is_numeric($targetId)) {
+                throw new \Exception('ID de formato inválido.');
+            }
+
+            if ($targetId === 'Yes') {
+                $artist->clearMediaCollection('artist_gallery');
+            }
+            if (is_numeric($targetId)) {
+                $mediaItem = $artist->media()->find($targetId);
+                if (!$mediaItem) {
+                    throw new \Exception('La imagen no existe o no tienes permisos para borrarla.');
+                }
+                $mediaItem->delete();
+            }
+
             DB::commit();
 
             return response()->json([
                 'success' => true,
-                'message' => 'Imagenes eliminadas'
+                'message' => 'Operación realizada con éxito'
             ], 200);
         } catch (\Exception $e) {
+            DB::rollBack();
             return response()->json([
                 'success' => false,
                 'message' => $e->getMessage()
@@ -541,24 +569,35 @@ class ArtistController extends Controller
         try {
             $artist = Artist::where('user_id', Auth::user()->id)->first();
             $count = ArtistVideo::where('artist_id', $artist->id)->count();
+            $urls = $request->input('youtube_urls', []);
+            if (!is_array($urls)) {
+                if ($request->has('youtube_url')) {
+                    $urls = [$request->input('youtube_url')];
+                }
+            }
+            $urls = array_filter($urls);
 
-            if ($count >= 3) {
-                return response()->json(['message' => 'Máximo 3 videos permitidos'], 422);
+            if (($count + count($urls)) > 3) {
+                return response()->json(['message' => 'Máximo 3 videos permitidos en total'], 422);
             }
 
-            $url = $request->youtube_url;
-            preg_match('/(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/', $url, $matches);
-
-            if (empty($matches[1])) {
-                return response()->json(['message' => 'URL de YouTube no válida'], 422);
+            $addedVideos = [];
+            foreach ($urls as $url) {
+                preg_match('/(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/', $url, $matches);
+                if (!empty($matches[1])) {
+                    $video = ArtistVideo::create([
+                        'artist_id'   => $artist->id,
+                        'youtube_url' => $matches[1],
+                    ]);
+                    $addedVideos[] = $video;
+                }
             }
 
-            $video = ArtistVideo::create([
-                'artist_id'   => $artist->id,
-                'youtube_url' => $matches[1],
-            ]);
+            if (count($addedVideos) === 0) {
+                return response()->json(['message' => 'Ninguna URL de YouTube fue válida'], 422);
+            }
 
-            return response()->json(['success' => true, 'artistVideo' => $video], 201);
+            return response()->json(['success' => true, 'artistVideos' => $addedVideos], 201);
         } catch (\Exception $e) {
             return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
         }


### PR DESCRIPTION
# Backend Changes Summary

## User Sanctions
- Updated the user sanctions logic to only consider cancellations from **artist sales that were accepted**.
- Added `whereHas` filters to exclude cancellations linked to unaccepted artist sales when:
  - Calculating recent cancellations.
  - Listing user cancellations.
  - Evaluating sanctions after a cancellation.
- Added a validation to prevent sanctions from being applied if the associated event was **not accepted by the artist**, returning an informative success response instead.

## Artist Gallery Management
- Refactored the gallery deletion endpoint to support deleting:
  - A specific media item by its ID.
  - The entire gallery when requested.
- Added support for receiving the media ID through multiple request sources (route parameter or request payload).
- Improved request validation by checking for missing or invalid media IDs.
- Added ownership validation to ensure artists can only delete their own gallery media.
- Improved transaction handling by rolling back database changes when an exception occurs.
- Updated the success response message to be more generic and reusable.

## Artist Video Management
- Enhanced the YouTube video upload endpoint to support **multiple video URLs** in a single request.
- Added compatibility for both:
  - `youtube_urls` (array input).
  - `youtube_url` (single URL input).
- Updated the maximum video validation to limit the **total number of videos to three**, including existing ones.
- Implemented batch processing to validate and store multiple YouTube videos.
- Added validation to ignore invalid YouTube URLs and return an error if none of the provided URLs are valid.
- Updated the API response to return the collection of newly created videos instead of a single video.