### PR TITLE
Feature: Fix cancelled approval workflow

### DIFF
--- a/app/Http/Controllers/Artist/ApprovalController.php
+++ b/app/Http/Controllers/Artist/ApprovalController.php
@@ -61,7 +61,7 @@ class ApprovalController extends Controller
             }
 
             $history = ArtistSale::where('artist_id', $artist->id)
-                ->whereIn('approval_status', [ArtistSale::APPROVAL_STATUS_ACCEPTED, ArtistSale::APPROVAL_STATUS_REJECTED, ArtistSale::APPROVAL_STATUS_EXPIRED])
+                ->whereIn('approval_status', [ArtistSale::APPROVAL_STATUS_ACCEPTED, ArtistSale::APPROVAL_STATUS_REJECTED, ArtistSale::APPROVAL_STATUS_EXPIRED, ArtistSale::APPROVAL_STATUS_CANCELLED])
                 ->with('customer')
                 ->orderByDesc('approval_responded_at')
                 ->get();

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -1320,6 +1320,10 @@ class PaymentController extends Controller
             $refundAmount = $originalRefundAmount;
 
             $sale->event_status = ArtistSale::EVENT_STATUS_CANCELLED;
+            if (in_array($sale->approval_status, [ArtistSale::APPROVAL_STATUS_PENDING, ArtistSale::APPROVAL_STATUS_ACCEPTED])) {
+                $sale->approval_status = ArtistSale::APPROVAL_STATUS_CANCELLED;
+                $sale->approval_responded_at = Carbon::now();
+            }
             $sale->save();
 
             EventCancellation::create([

--- a/app/Models/ArtistSale.php
+++ b/app/Models/ArtistSale.php
@@ -23,6 +23,7 @@ class ArtistSale extends Model
     const APPROVAL_STATUS_ACCEPTED = 'accepted';
     const APPROVAL_STATUS_REJECTED = 'rejected';
     const APPROVAL_STATUS_EXPIRED = 'expired';
+    const APPROVAL_STATUS_CANCELLED = 'cancelled';
 
     const PAYMENT_METHOD_CARD = 'card';
     const PAYMENT_METHOD_CASH = 'cash';

--- a/database/migrations/2026_07_22_000001_add_cancelled_to_approval_status_check.php
+++ b/database/migrations/2026_07_22_000001_add_cancelled_to_approval_status_check.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE artist_sales DROP CONSTRAINT IF EXISTS artist_sales_approval_status_check');
+        DB::statement("
+            ALTER TABLE artist_sales
+            ADD CONSTRAINT artist_sales_approval_status_check
+            CHECK (approval_status IN ('pending_approval', 'accepted', 'rejected', 'expired', 'cancelled'))
+        ");
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE artist_sales DROP CONSTRAINT IF EXISTS artist_sales_approval_status_check');
+        DB::statement("
+            ALTER TABLE artist_sales
+            ADD CONSTRAINT artist_sales_approval_status_check
+            CHECK (approval_status IN ('pending_approval', 'accepted', 'rejected', 'expired'))
+        ");
+    }
+};

--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -50,19 +50,19 @@ class ArtistSalesSeeder extends Seeder
                 $createdAt = Carbon::now()->addDays($createdAtOffsets[($customerIndex + $j) % count($createdAtOffsets)]);
 
                 $approvalStatus = $statusPattern['approval_status'];
-                $approvalDeadline = null;
-                $approvalRespondedAt = null;
 
-                if ($approvalStatus === ArtistSale::APPROVAL_STATUS_PENDING) {
-                    $approvalDeadline = Carbon::now()->addHours(24);
-                } elseif ($approvalStatus === ArtistSale::APPROVAL_STATUS_ACCEPTED) {
-                    $approvalDeadline = (clone $createdAt)->addHours(24);
-                    $approvalRespondedAt = (clone $createdAt)->addHours(2);
-                } elseif (in_array($approvalStatus, [ArtistSale::APPROVAL_STATUS_REJECTED, ArtistSale::APPROVAL_STATUS_EXPIRED])) {
-                    $approvalDeadline = (clone $createdAt)->addHours(24);
-                    $approvalRespondedAt = $approvalStatus === ArtistSale::APPROVAL_STATUS_REJECTED
-                        ? (clone $createdAt)->addHours(4) : null;
-                }
+                $respondHours = [
+                    ArtistSale::APPROVAL_STATUS_ACCEPTED => 2,
+                    ArtistSale::APPROVAL_STATUS_REJECTED => 4,
+                ];
+
+                $approvalDeadline = $approvalStatus === ArtistSale::APPROVAL_STATUS_PENDING
+                    ? Carbon::now()->addHours(24)
+                    : (clone $createdAt)->addHours(24);
+
+                $approvalRespondedAt = isset($respondHours[$approvalStatus])
+                    ? (clone $createdAt)->addHours($respondHours[$approvalStatus])
+                    : null;
 
                 $sale = ArtistSale::create([
                     'artist_id'              => $artistId,

--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -29,9 +29,9 @@ class ArtistSalesSeeder extends Seeder
         $createdAtOffsets = [-150, -120, -90, -75, -60, -30, -20, -10];
         $paymentMethods   = ['card', 'cash'];
         $salesPattern = [
-            ['status' => ArtistSale::PAYMENT_STATUS_COMPLETED, 'event_status' => ArtistSale::EVENT_STATUS_COMPLETED],
-            ['status' => ArtistSale::PAYMENT_STATUS_COMPLETED, 'event_status' => ArtistSale::EVENT_STATUS_PENDING],
-            ['status' => ArtistSale::PAYMENT_STATUS_PENDING,   'event_status' => ArtistSale::EVENT_STATUS_PENDING],
+            ['status' => ArtistSale::PAYMENT_STATUS_COMPLETED, 'event_status' => ArtistSale::EVENT_STATUS_COMPLETED, 'approval_status' => ArtistSale::APPROVAL_STATUS_ACCEPTED],
+            ['status' => ArtistSale::PAYMENT_STATUS_COMPLETED, 'event_status' => ArtistSale::EVENT_STATUS_PENDING,   'approval_status' => ArtistSale::APPROVAL_STATUS_ACCEPTED],
+            ['status' => ArtistSale::PAYMENT_STATUS_PENDING,   'event_status' => ArtistSale::EVENT_STATUS_PENDING,  'approval_status' => ArtistSale::APPROVAL_STATUS_PENDING],
         ];
 
         foreach ($customers as $customerIndex => $customer) {
@@ -47,7 +47,22 @@ class ArtistSalesSeeder extends Seeder
                     : 0.00;
 
                 $eventDate = Carbon::now()->addDays($eventDateOffsets[($customerIndex + $j) % count($eventDateOffsets)])->format('Y-m-d');
-                $createdAt = Carbon::now()->addDays($createdAtOffsets[($customerIndex + $j) % count($createdAtOffsets)])->format('Y-m-d H:i:s');
+                $createdAt = Carbon::now()->addDays($createdAtOffsets[($customerIndex + $j) % count($createdAtOffsets)]);
+
+                $approvalStatus = $statusPattern['approval_status'];
+                $approvalDeadline = null;
+                $approvalRespondedAt = null;
+
+                if ($approvalStatus === ArtistSale::APPROVAL_STATUS_PENDING) {
+                    $approvalDeadline = Carbon::now()->addHours(24);
+                } elseif ($approvalStatus === ArtistSale::APPROVAL_STATUS_ACCEPTED) {
+                    $approvalDeadline = (clone $createdAt)->addHours(24);
+                    $approvalRespondedAt = (clone $createdAt)->addHours(2);
+                } elseif (in_array($approvalStatus, [ArtistSale::APPROVAL_STATUS_REJECTED, ArtistSale::APPROVAL_STATUS_EXPIRED])) {
+                    $approvalDeadline = (clone $createdAt)->addHours(24);
+                    $approvalRespondedAt = $approvalStatus === ArtistSale::APPROVAL_STATUS_REJECTED
+                        ? (clone $createdAt)->addHours(4) : null;
+                }
 
                 $sale = ArtistSale::create([
                     'artist_id'              => $artistId,
@@ -69,7 +84,9 @@ class ArtistSalesSeeder extends Seeder
                     'payment_method'         => $paymentMethod,
                     'event_status'           => $statusPattern['event_status'],
                     'status'                 => $statusPattern['status'],
-                    'approval_status'        => ArtistSale::APPROVAL_STATUS_ACCEPTED, // --- CONSTANTE AQUÍ TAMBIÉN ---
+                    'approval_status'        => $approvalStatus,
+                    'approval_deadline'      => $approvalDeadline,
+                    'approval_responded_at'  => $approvalRespondedAt,
                     'created_at'             => $createdAt,
                     'updated_at'             => $createdAt,
                 ]);


### PR DESCRIPTION
**Summary**

This PR fixes the approval cancellation workflow so that cancelled requests are no longer displayed in the artist's pending approvals.

When a request is cancelled, it is now removed from the pending list and moved to the approval history with the Cancelled status, providing a more accurate representation of the request lifecycle.

**Changes Implemented**
🔹 Approval Workflow

- Fixed the cancellation flow for artist approval requests.
- Removed cancelled requests from the pending approvals list.
- Added support for displaying cancelled requests in the approval history.
- Updated the approval status handling to include the cancelled state.

🔹 Business Logic

- Improved approval status transitions.
- Updated payment and approval logic to respect the new cancelled status.
- Updated seed data to reflect the new approval workflow.

🔹 Database

- Added support for the cancelled approval status through a new migration.

**📁 Files Modified**

Backend

Controllers

- app/Http/Controllers/Artist/ApprovalController.php
- app/Http/Controllers/PaymentController.php

Models

- app/Models/ArtistSale.php

Seeders

- database/seeders/ArtistSalesSeeder.php

Migrations

- database/migrations/2026_07_22_000001_add_cancelled_to_approval_status_check.php
