### PR TITLE
Remove is_active filter and handle validation errors

### DIFF
--- a/app/Http/Controllers/Artist/ArtistController.php
+++ b/app/Http/Controllers/Artist/ArtistController.php
@@ -501,8 +501,7 @@ class ArtistController extends Controller
                 'manager',
                 'user:id,account_status',
                 'offers' => function ($query) {
-                $query->where('is_active', true)
-                    ->where('start_date', '<=', now())
+                    $query->where('start_date', '<=', now())
                     ->where('end_date', '>=', now());
                 }
             ])

--- a/app/Http/Controllers/Artist/OfferController.php
+++ b/app/Http/Controllers/Artist/OfferController.php
@@ -22,6 +22,7 @@ class OfferController extends Controller
                 $offer->has_pending_sale = ArtistSale::where('offer_id', $offer->id)
                     ->where('approval_status', ArtistSale::APPROVAL_STATUS_PENDING)
                     ->exists();
+                $offer->is_active = now()->between($offer->start_date, $offer->end_date);
             });
 
             return response()->json(['success' => true, 'offers' => $offers], 200);
@@ -52,6 +53,12 @@ class OfferController extends Controller
             ]);
 
             return response()->json(['success' => true, 'offer' => $offer], 201);
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Hay campos inválidos o faltantes en el formulario.',
+                'errors'  => $e->errors(),
+            ], 422);
         } catch (\Exception $e) {
             return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
         }
@@ -79,6 +86,12 @@ class OfferController extends Controller
             ]);
 
             return response()->json(['success' => true, 'offer' => $offer], 200);
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Hay campos inválidos o faltantes en el formulario.',
+                'errors'  => $e->errors(),
+            ], 422);
         } catch (\Exception $e) {
             return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
         }

--- a/app/Http/Controllers/Client/FavouriteArtist/FavouriteArtistsController.php
+++ b/app/Http/Controllers/Client/FavouriteArtist/FavouriteArtistsController.php
@@ -23,8 +23,7 @@ class FavouriteArtistsController extends Controller
         try {
             $now = Carbon::now('America/Mexico_City')->format('Y-m-d H:i:s');
             $favouriteArtists = FavouriteArtists::with(['artist', 'artist.offers' => function ($query) use ($now) {
-                $query->where('is_active', true)
-                    ->where('start_date', '<=', $now)
+                $query->where('start_date', '<=', $now)
                     ->where('end_date', '>=', $now);
             }])->where('user_id', Auth::user()->id)->get();
             return response()->json([

--- a/app/Http/Controllers/Client/GendersController.php
+++ b/app/Http/Controllers/Client/GendersController.php
@@ -60,8 +60,7 @@ class GendersController extends Controller
                 'artistVideos',
                 'user:id,account_status',
                 'offers' => function ($query) {
-                    $query->where('is_active', true)
-                        ->where('start_date', '<=', now())
+                    $query->where('start_date', '<=', now())
                         ->where('end_date', '>=', now())
                         ->orderBy('discount_percentage', 'desc')
                         ->limit(1);

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -100,7 +100,6 @@ class PaymentController extends Controller
 
                 $now = Carbon::now()->format('Y-m-d H:i:s');
                 $activeOffer = Offer::where('artist_id', $artist->id)
-                    ->where('is_active', true)
                     ->where('start_date', '<=', $now)
                     ->where('end_date', '>=', $now)
                     ->orderBy('discount_percentage', 'desc')
@@ -785,7 +784,6 @@ class PaymentController extends Controller
 
                 $now = Carbon::now()->format('Y-m-d H:i:s');
                 $activeOffer = Offer::where('artist_id', $artist->id)
-                    ->where('is_active', true)
                     ->where('start_date', '<=', $now)
                     ->where('end_date', '>=', $now)
                     ->orderBy('discount_percentage', 'desc')


### PR DESCRIPTION
## 📝 Description
This Pull Request refactors how offer validity is checked across the application by removing the strict `is_active` database query constraint in favor of active date ranges (`start_date` and `end_date`). Additionally, it introduces explicit `ValidationException` handling for offer management endpoints.

---

## 🔍 Context & Problem
1. **Rigid Offer Querying:** Multiple endpoints relied on an `is_active` boolean field in query builders, which created discrepancies when offers were active by date but flagged inactive in DB or vice versa.
2. **Generic Exception Responses:** Failed validations in offer creation and updates were not returning structured JSON responses with detailed field-level error messages (code 422).

---

## 🚀 Key Changes & Architecture

### 🎟️ Offer Query Logic (`ArtistController.php`, `FavouriteArtistsController.php`, `GendersController.php`, `PaymentController.php`)
- **Query Relaxation:** Removed `where('is_active', true)` conditions across offer queries (artist profiles, favorites, genres, and payment calculations) to rely entirely on `start_date <= now()` and `end_date >= now()`.

### 🛡️ Validation & Exception Handling (`OfferController.php`)
- **Dynamic Flag Assignment:** Added `$offer->is_active = now()->between(...)` dynamic computation when returning active offers.
- **Validation Catching:** Added `catch (\Illuminate\Validation\ValidationException $e)` blocks in `store` and `update` actions to return structured `422 Unprocessable Entity` JSON responses containing error arrays.

---

## 🧪 Testing Checklist
- [ ] Attempt to create/update an offer with invalid or missing fields and verify a `422` JSON error response is returned.
- [ ] Create an offer with a valid date range and verify it appears on the artist profile and checkout calculation without depending on the `is_active` DB column.