### PR TITLE
prevent admins from applying sanctions to their own accounts

### DIFF
--- a/app/Http/Controllers/Admin/UserSanctionController.php
+++ b/app/Http/Controllers/Admin/UserSanctionController.php
@@ -324,6 +324,12 @@ class UserSanctionController extends Controller
                     'message' => 'Error por campos vacíos',
                 ], 422);
             }
+            if ($userId == auth()->id()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Acción denegada: No tienes permitido aplicar una sanción a tu propia cuenta.'
+                ], 403);
+            }
 
             $ticket = SupportTicket::find($ticketId);
 


### PR DESCRIPTION
# Backend Changes Summary

## User Sanction Logic

### Improvements
- Added a validation to prevent administrators from applying sanctions to their own accounts.
- Introduced an authorization check that compares the target user ID with the authenticated user's ID before processing the sanction.
- Returns a **403 Forbidden** response with a clear error message when a self-sanction attempt is detected.
- Improves system integrity by preventing accidental or unauthorized self-sanction actions.