### PR TITLE
Add ArtistCompletableEventsSeeder to DatabaseSeeder

### DIFF
--- a/database/seeders/ArtistCompletableEventsSeeder.php
+++ b/database/seeders/ArtistCompletableEventsSeeder.php
@@ -23,7 +23,7 @@ class ArtistCompletableEventsSeeder extends Seeder
             return;
         }
 
-        $paymentMethods = ['card', 'cash'];
+        $paymentMethods = [ArtistSale::PAYMENT_METHOD_CARD, ArtistSale::PAYMENT_METHOD_CASH];
         $customerCursor = 0;
 
         foreach ($artistIds as $artistIndex => $artistId) {
@@ -46,7 +46,7 @@ class ArtistCompletableEventsSeeder extends Seeder
                 $eventHour = $eventStart->format('H:i:s');
 
                 $amount = (float) $artist->price_hour * $eventHours;
-                $openpayFee = $paymentMethod === 'card'
+                $openpayFee = $paymentMethod === ArtistSale::PAYMENT_METHOD_CARD
                     ? round(($amount * 0.029) * 1.16, 2)
                     : 0.00;
 
@@ -79,7 +79,7 @@ class ArtistCompletableEventsSeeder extends Seeder
                     'updated_at' => $createdAt,
                 ]);
 
-                if ($paymentMethod === 'cash') {
+                if ($paymentMethod === ArtistSale::PAYMENT_METHOD_CASH) {
                     $sale->cashReference()->create([
                         'cash_reference' => 'REF-' . strtoupper(uniqid()),
                         'cash_barcode_url' => 'https://sandbox-dashboard.openpay.mx/barcode/test_' . $sale->id . '.png',

--- a/database/seeders/ArtistCompletableEventsSeeder.php
+++ b/database/seeders/ArtistCompletableEventsSeeder.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Artist;
+use App\Models\ArtistSale;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ArtistCompletableEventsSeeder extends Seeder
+{
+    public function run()
+    {
+        $artistIds = DB::table('artists')->orderBy('id')->pluck('id')->all();
+
+        $customers = User::whereHas('roles', function ($q) {
+            $q->where('slug', User::ROLE_CLIENT);
+        })->orderBy('id')->get()->values();
+
+        if (empty($artistIds) || $customers->isEmpty()) {
+            return;
+        }
+
+        $paymentMethods = ['card', 'cash'];
+        $customerCursor = 0;
+
+        foreach ($artistIds as $artistIndex => $artistId) {
+            $artist = Artist::find($artistId);
+            if (!$artist) {
+                continue;
+            }
+
+            for ($eventIndex = 0; $eventIndex < 2; $eventIndex++) {
+                $customer = $customers[$customerCursor % $customers->count()];
+                $customerCursor++;
+
+                $paymentMethod = $paymentMethods[($artistIndex + $eventIndex) % count($paymentMethods)];
+                $eventHours = 1;
+                $hoursAgoEnded = $eventIndex === 0 ? 3 : 8;
+                $eventEnd = Carbon::now()->subHours($hoursAgoEnded);
+                $eventStart = (clone $eventEnd)->subHours($eventHours);
+
+                $eventDate = $eventStart->format('Y-m-d');
+                $eventHour = $eventStart->format('H:i:s');
+
+                $amount = (float) $artist->price_hour * $eventHours;
+                $openpayFee = $paymentMethod === 'card'
+                    ? round(($amount * 0.029) * 1.16, 2)
+                    : 0.00;
+
+                $createdAt = Carbon::now()->subDays(2);
+
+                $sale = ArtistSale::create([
+                    'artist_id' => $artist->id,
+                    'customer_id' => $customer->id,
+                    'amount' => $amount,
+                    'openpay_fee' => $openpayFee,
+                    'openpay_transaction_id' => 'trx_completable_' . $artist->id . '_' . $customer->id . '_' . $eventIndex,
+                    'customer_first_name' => explode(' ', $customer->name)[0],
+                    'customer_last_name' => explode(' ', $customer->name)[1] ?? 'Usuario',
+                    'customer_email' => $customer->email,
+                    'customer_phone' => '5512345678',
+                    'customer_address' => 'Calle Principal 123',
+                    'customer_city' => 'Ciudad de México',
+                    'customer_state' => 'CDMX',
+                    'customer_zip_code' => '28001',
+                    'event_date' => $eventDate,
+                    'event_hour' => $eventHour,
+                    'event_hours' => $eventHours,
+                    'payment_method' => $paymentMethod,
+                    'event_status' => ArtistSale::EVENT_STATUS_PENDING,
+                    'status' => ArtistSale::PAYMENT_STATUS_COMPLETED,
+                    'approval_status' => ArtistSale::APPROVAL_STATUS_ACCEPTED,
+                    'approval_deadline' => (clone $createdAt)->addHours(24),
+                    'approval_responded_at' => (clone $createdAt)->addHours(2),
+                    'created_at' => $createdAt,
+                    'updated_at' => $createdAt,
+                ]);
+
+                if ($paymentMethod === 'cash') {
+                    $sale->cashReference()->create([
+                        'cash_reference' => 'REF-' . strtoupper(uniqid()),
+                        'cash_barcode_url' => 'https://sandbox-dashboard.openpay.mx/barcode/test_' . $sale->id . '.png',
+                        'cash_due_date' => Carbon::parse($createdAt)->addDays(3),
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -41,5 +41,6 @@ class DatabaseSeeder extends Seeder
         $this->call(FavouriteArtistsSeeder::class);
         $this->call(OfferSeeder::class);
         $this->call(UserSanctionSeeder::class);
+        $this->call(ArtistCompletableEventsSeeder::class);
     }
 }


### PR DESCRIPTION
## 📝 Description
This Pull Request introduces a new database seeder `ArtistCompletableEventsSeeder` and registers it within `DatabaseSeeder` to populate initial completable events data for artists.

---

## 🔍 Context & Problem
1. **Missing Initial Seeder Data:** Development and staging environments lacked seed data for artist completable events, requiring manual setup or testing without populated events.

---

## 🚀 Key Changes & Architecture

### 🌱 Database Seeders (`database/seeders/`)
- **`ArtistCompletableEventsSeeder.php`:** Created new seeder class to handle population of completable events for artists.
- **`DatabaseSeeder.php`:** Registered `$this->call(ArtistCompletableEventsSeeder::class);` into the main database execution pipeline.

---

## 🧪 Testing Checklist
- [ ] Run `php artisan db:seed` or `php artisan migrate:fresh --seed`.
- [ ] Verify that `ArtistCompletableEventsSeeder` executes successfully without errors and seeds the corresponding database table.