### PR TITLE
Handle validation exception in user controller and custom email unique message

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -212,6 +212,12 @@ class UsersController extends Controller
                 'image_profile' => $absoluteImageUrl,
                 'image' => $absoluteImageUrl,
             ], 200);
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Hay campos inválidos o faltantes en el formulario.',
+                'errors'  => $e->errors(),
+            ], 422);
         } catch (\Exception $e) {
             DB::rollback();
             return response()->json([

--- a/app/Http/Requests/Auth/UserRegisterRequest.php
+++ b/app/Http/Requests/Auth/UserRegisterRequest.php
@@ -30,4 +30,11 @@ class UserRegisterRequest extends FormRequest
 
         ];
     }
+
+    public function messages()
+    {
+        return [
+            'email.unique' => 'Este correo ya existe.',
+        ];
+    }
 }


### PR DESCRIPTION
## 📝 Description
This Pull Request improves registration validation feedback by adding explicit `ValidationException` handling in `UsersController` and introducing a custom translation message for duplicate email errors.

---

## 🔍 Context & Problem
1. **Uncaught Validation Exception:** Exceptions during user registration were getting caught by generic exception handlers, leading to 500 errors instead of structured 422 validation responses.
2. **Default Error Messages:** Email uniqueness validation failed to provide a localized, user-friendly error message.

---

## 🚀 Key Changes & Architecture

### 👤 User Registration & Controller (`UsersController.php`, `UserRegisterRequest.php`)
- **Validation Exception Catch:** Wrapped user registration flow with `catch (\Illuminate\Validation\ValidationException $e)` returning structured `422 Unprocessable Entity` JSON responses.
- **Custom Message:** Added `messages()` method in `UserRegisterRequest` mapping `email.unique` to `'Este correo ya existe.'`.

---

## 🧪 Testing Checklist
- [ ] Attempt registering a user with an already existing email and verify a `422` response with `'Este correo ya existe.'`.
- [ ] Send missing/invalid registration parameters and verify structured JSON error messages.