### PR TITLE
Feature: Fix client cancellation penalty

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -1317,6 +1317,8 @@ class PaymentController extends Controller
             $penaltyAmount = $originalPenaltyAmount;
             $refundAmount = $originalRefundAmount;
 
+            $originalApprovalStatus = $sale->approval_status;
+
             $sale->event_status = ArtistSale::EVENT_STATUS_CANCELLED;
             if (in_array($sale->approval_status, [ArtistSale::APPROVAL_STATUS_PENDING, ArtistSale::APPROVAL_STATUS_ACCEPTED])) {
                 $sale->approval_status = ArtistSale::APPROVAL_STATUS_CANCELLED;
@@ -1334,7 +1336,7 @@ class PaymentController extends Controller
                 'penalty_paid' => true,
             ]);
 
-            $this->sendCancellationEmails($sale, $request->reason, 'client', $refundAmount, $penaltyAmount, $penaltyPercentage);
+            $this->sendCancellationEmails($sale, $request->reason, 'client', $refundAmount, $penaltyAmount, $penaltyPercentage, $originalApprovalStatus);
 
             return response()->json([
                 'success' => true,
@@ -1350,14 +1352,14 @@ class PaymentController extends Controller
         }
     }
 
-    private function sendCancellationEmails(ArtistSale $sale, string $reason, string $cancelledBy, float $refundAmount, float $penaltyAmount, int $penaltyPercentage = 0)
+    private function sendCancellationEmails(ArtistSale $sale, string $reason, string $cancelledBy, float $refundAmount, float $penaltyAmount, int $penaltyPercentage = 0, ?string $originalApprovalStatus = null)
     {
         $clientEmail = $sale->customer_email;
 
         $artistUser = Artist::where('id', $sale->artist_id)->with('user')->first()?->user;
         $artistEmail = $artistUser ? $artistUser->email : null;
 
-        $isBeforeApproval = $cancelledBy === 'client' && $sale->approval_status !== ArtistSale::APPROVAL_STATUS_ACCEPTED;
+        $isBeforeApproval = $cancelledBy === 'client' && $originalApprovalStatus !== ArtistSale::APPROVAL_STATUS_ACCEPTED;
 
         if ($clientEmail) {
             try {


### PR DESCRIPTION
**Summary**

This PR fixes the business logic applied when a client cancels an event one day before its scheduled date. The penalty calculation has been corrected to ensure the appropriate amount is applied according to the cancellation policy.

**Changes Implemented**

🔹 Cancellation Logic

- Corrected the penalty calculation for client event cancellations.
- Updated the cancellation workflow.
- Improved consistency in penalty processing.

**📁 Files Modified**

Backend

Controllers

- app/Http/Controllers/PaymentController.php