### PR TITLE
add customer to event reminder notifications

### DIFF
--- a/app/Console/Commands/SendEventReminders.php
+++ b/app/Console/Commands/SendEventReminders.php
@@ -12,7 +12,7 @@ use Carbon\Carbon;
 class SendEventReminders extends Command
 {
     protected $signature = 'events:send-reminders';
-    protected $description = 'Envía recordatorio al artista 24h antes del evento';
+    protected $description = 'Envía recordatorio al artista y cliente 24h antes del evento';
 
     public function handle()
     {
@@ -41,16 +41,28 @@ class SendEventReminders extends Command
                     continue;
                 }
 
-                Mail::to($artistUser->email)->send(new EventReminderNotification($sale));
-                $sale->reminder_sent_at = now();
-                $sale->save();
-                $count++;
-
+                Mail::to($artistUser->email)->send(new EventReminderNotification($sale, 'artist'));
                 Log::info('Recordatorio enviado al artista', [
                     'sale_id' => $sale->id,
                     'artist' => $artistUser->email,
                     'event_date' => $sale->event_date,
                 ]);
+
+                $customer = $sale->customer;
+                if (!$customer || !$customer->email) {
+                    Log::warning('Recordatorio: email de cliente no encontrado', ['sale_id' => $sale->id]);
+                }
+                if ($customer && $customer->email) {
+                    Mail::to($customer->email)->send(new EventReminderNotification($sale, 'customer'));
+                    Log::info('Recordatorio enviado al cliente', [
+                        'sale_id' => $sale->id,
+                        'customer' => $customer->email,
+                        'event_date' => $sale->event_date,
+                    ]);
+                }
+                $sale->reminder_sent_at = now();
+                $sale->save();
+                $count++;
             } catch (\Exception $e) {
                 Log::error('Error enviando recordatorio', [
                     'sale_id' => $sale->id,

--- a/app/Mail/EventReminderNotification.php
+++ b/app/Mail/EventReminderNotification.php
@@ -13,10 +13,12 @@ class EventReminderNotification extends Mailable
 
     public $sale;
     public $frontendUrl;
+    public $recipientType;
 
-    public function __construct(ArtistSale $sale)
+    public function __construct(ArtistSale $sale, string $recipientType)
     {
         $this->sale = $sale;
+        $this->recipientType = $recipientType;
         $this->frontendUrl = config('app.frontend_url');
     }
 

--- a/resources/views/emails/event-reminder.blade.php
+++ b/resources/views/emails/event-reminder.blade.php
@@ -29,22 +29,42 @@
                         <td class="newsletter-hero">
                             <img src="{{ $message->embed(public_path('logovibeer.png')) }}" alt="Vibeer" class="newsletter-logo">
                             <h1 class="newsletter-title" style="margin-top: 12px;">Recordatorio de evento</h1>
-                            <p style="font-size: 16px; margin-bottom: 4px;">Hola {{ $sale->artist->name ?? 'artista' }},</p>
-                            <p class="newsletter-subtitle">Tienes un evento programado para ma&ntilde;ana. Aqu&iacute; est&aacute;n los detalles:</p>
+                            @if($recipientType === 'artist')
+                                <p style="font-size: 16px; margin-bottom: 4px;">Hola {{ $sale->artist->name ?? 'artista' }},</p>
+                                <p class="newsletter-subtitle">Tienes un evento programado para ma&ntilde;ana. Aqu&iacute; est&aacute;n los detalles:</p>
+                            @endif
+                            @if($recipientType === 'customer')
+                                <p style="font-size: 16px; margin-bottom: 4px;">Hola {{ $sale->customer_first_name }},</p>
+                                <p class="newsletter-subtitle">Tu evento es ma&ntilde;ana. Aqu&iacute; est&aacute;n los detalles de la presentaci&oacute;n:</p>
+                            @endif
                         </td>
                     </tr>
                     <tr>
                         <td class="newsletter-content">
                             <div class="newsletter-body">
-                                <div class="highlight">
-                                    <strong>Recuerda:</strong> Este evento comienza en menos de 24 horas. Aseg&uacute;rate de llegar puntual.
-                                </div>
-
-                                <div class="info-grid">
-                                    <div class="info-row">
-                                        <span class="info-label">Cliente</span>
-                                        <span class="info-value">{{ $sale->customer_first_name }} {{ $sale->customer_last_name }}</span>
+                                @if($recipientType === 'artist')
+                                    <div class="highlight">
+                                        <strong>Recuerda:</strong> Este evento comienza en menos de 24 horas. Aseg&uacute;rate de llegar puntual.
                                     </div>
+                                @endif
+                                @if($recipientType === 'customer')
+                                    <div class="highlight">
+                                        <strong>Recuerda:</strong> Este evento comienza en menos de 24 horas. &iexcl;Prep&aacute;rate para disfrutar de la m&uacute;sica!
+                                    </div>
+                                @endif
+                                <div class="info-grid">
+                                    @if($recipientType === 'artist')
+                                        <div class="info-row">
+                                            <span class="info-label">Cliente</span>
+                                            <span class="info-value">{{ $sale->customer_first_name }} {{ $sale->customer_last_name }}</span>
+                                        </div>
+                                    @endif
+                                    @if($recipientType === 'customer')
+                                        <div class="info-row">
+                                            <span class="info-label">Artista</span>
+                                            <span class="info-value">{{ $sale->artist->name ?? 'Artista' }}</span>
+                                        </div>
+                                    @endif
                                     <div class="info-row">
                                         <span class="info-label">Fecha</span>
                                         <span class="info-value">{{ Carbon::parse($sale->event_date)->locale('es')->isoFormat('dddd D [de] MMMM [de] YYYY') }}</span>
@@ -64,9 +84,16 @@
                                 </div>
 
                                 <div style="margin-top: 28px; text-align: center;">
-                                    <a href="{{ $frontendUrl }}/artist/my-calendar" target="_blank" class="btn btn-primary" style="color: #fff; background: #094FAB;">
-                                        Ver mi calendario
-                                    </a>
+                                    @if($recipientType === 'artist')
+                                        <a href="{{ $frontendUrl }}/artist/my-calendar" target="_blank" class="btn btn-primary" style="color: #fff; background: #094FAB;">
+                                            Ver mi calendario
+                                        </a>
+                                    @endif
+                                    @if($recipientType === 'customer')
+                                        <a href="{{ $frontendUrl }}/client/shopping-cart/view-my-order-details" target="_blank" class="btn btn-primary" style="color: #fff; background: #094FAB;">
+                                            Ver mi compra
+                                        </a>
+                                    @endif
                                 </div>
                             </div>
                         </td>


### PR DESCRIPTION
## Summary

- Enhanced the event reminder workflow to send notifications to both artists and customers 24 hours before an event instead of only notifying artists.
- Updated the reminder command to handle customer email delivery, add logging for both recipients, validate customer email availability, and mark reminders as sent only after processing.
- Extended the `EventReminderNotification` mailable to support different recipient types by introducing a `recipientType` parameter.
- Refactored the event reminder email template to display personalized content based on the recipient (artist or customer), including customized greetings, reminder messages, event details, and action buttons.
- Added customer-specific event information, such as the assigned artist and a direct link to view their purchase, while preserving artist-specific event details and calendar access.
- Improved email notification logging and error handling for missing customer email addresses, making the reminder process more reliable and easier to monitor.