### PR TITLE
Enable JPEG support and install gd extension in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     git \
     curl \
     libpng-dev \
+    libjpeg-dev \
     libonig-dev \
     libxml2-dev \
     zip \
@@ -17,7 +18,8 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update
 RUN apt-get install -y libpq-dev
-RUN docker-php-ext-install pdo pdo_mysql pdo_pgsql exif
+RUN docker-php-ext-configure gd --with-jpeg
+RUN docker-php-ext-install pdo pdo_mysql pdo_pgsql exif gd
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 


### PR DESCRIPTION
## 📝 Description
This Pull Request updates the application `Dockerfile` to install `libjpeg-dev` and configure the PHP `gd` extension with JPEG support.

---

## 🔍 Context & Problem
1. **Missing Image Processing Dependencies:** The Docker PHP environment lacked the GD extension configured with JPEG support, causing image manipulation or processing operations involving JPEG/JPG files to fail inside containerized environments.

---

## 🚀 Key Changes & Architecture

### 🐳 Container Configuration (`Dockerfile`)
- **Libjpeg Dependency:** Added `libjpeg-dev` to the system package installation step via `apt-get`.
- **PHP Extension Setup:** Added `RUN docker-php-ext-configure gd --with-jpeg` and registered `gd` within `docker-php-ext-install`.

---

## 🧪 Testing Checklist
- [ ] Build the Docker image locally via `docker build -t backend-music .`.
- [ ] Verify that PHP GD extension is enabled with JPEG support (`php -i | grep -i gd`).