### PR TITLE
add StatsController and API routes for admin artist analytics

### DIFF
--- a/app/Http/Controllers/Admin/ArtistStatsController.php
+++ b/app/Http/Controllers/Admin/ArtistStatsController.php
@@ -11,7 +11,7 @@ use App\Models\UserSanction;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
-class StatsController extends Controller
+class ArtistStatsController extends Controller
 {
     private function getMonthName(int $month): string
     {

--- a/app/Http/Controllers/Admin/StatsController.php
+++ b/app/Http/Controllers/Admin/StatsController.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Carbon\Carbon;
+use App\Models\Artist;
+use App\Models\ArtistSale;
+use App\Models\ArtistRating;
+use App\Models\UserSanction;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class StatsController extends Controller
+{
+    private function getMonthName(int $month): string
+    {
+        $months = [
+            1 => 'Enero',    2 => 'Febrero',   3 => 'Marzo',
+            4 => 'Abril',    5 => 'Mayo',       6 => 'Junio',
+            7 => 'Julio',    8 => 'Agosto',     9 => 'Septiembre',
+            10 => 'Octubre', 11 => 'Noviembre', 12 => 'Diciembre'
+        ];
+        return $months[$month] ?? 'Mes ' . $month;
+    }
+
+    private function formatDate(Carbon $date): string
+    {
+        $day   = $date->format('d');
+        $month = $this->getMonthName((int) $date->format('n'));
+        $year  = $date->format('Y');
+        return "{$day} de {$month} de {$year}";
+    }
+
+    private function calcTrend(float $current, float $previous, string $suffix = 'nuevos'): string
+    {
+        if ($previous == 0 && $current == 0) {
+            return 'Sin datos';
+        }
+        if ($previous == 0) {
+            return '+' . number_format($current, 0) . ' ' . $suffix;
+        }
+        $change  = (($current - $previous) / $previous) * 100;
+        $sign    = $change >= 0 ? '+' : '';
+        $rounded = number_format(abs($change), 1);
+        return $sign . ($change < 0 ? '-' : '') . $rounded . '%';
+    }
+
+    private function calcRatingTrend(float $current, float $previous): string
+    {
+        if ($previous == 0 && $current == 0) {
+            return 'Sin datos';
+        }
+        if ($previous == 0) {
+            return '+' . number_format($current, 1) . ' pts en el período';
+        }
+        $diff = $current - $previous;
+        $sign = $diff >= 0 ? '+' : '';
+        return $sign . number_format($diff, 1) . ' pts';
+    }
+
+    private function calcIncomeTrend(float $current, float $previous): string
+    {
+        if ($previous == 0 && $current == 0) {
+            return 'Sin datos';
+        }
+        if ($previous == 0) {
+            return '+$' . number_format($current, 2) . ' en el período';
+        }
+        $change  = (($current - $previous) / $previous) * 100;
+        $sign    = $change >= 0 ? '+' : '';
+        $rounded = number_format(abs($change), 1);
+        return $sign . ($change < 0 ? '-' : '') . $rounded . '%';
+    }
+
+    private function calculateNetIncome($sales): float
+    {
+        return (float) $sales->sum(function ($sale) {
+            $amount      = floatval($sale->amount);
+            $openpayFee  = floatval($sale->openpay_fee);
+            $platformFee = $amount * 0.10;
+            return max(0, $amount - $openpayFee - $platformFee);
+        });
+    }
+
+    private function getChartData(string $filter, int $artistId): array
+    {
+        $chartLabels = [];
+        $chartSeries = [];
+        if ($filter === 'Por semana' || strtolower($filter) === 'week') {
+            $incomeByWeek = [];
+            for ($w = 5; $w >= 0; $w--) {
+                $weekKey = Carbon::now()->startOfWeek()->subWeeks($w)->format('Y-W');
+                $incomeByWeek[$weekKey] = 0;
+            }
+            $sixWeeksAgo = Carbon::now()->startOfWeek()->subWeeks(5);
+            $salesLastWeeks = ArtistSale::where('artist_id', $artistId)
+                ->where('event_status', ArtistSale::EVENT_STATUS_COMPLETED)
+                ->where('created_at', '>=', $sixWeeksAgo)
+                ->get();
+            foreach ($salesLastWeeks as $sale) {
+                $weekKey = Carbon::parse($sale->created_at)->format('Y-W');
+                if (isset($incomeByWeek[$weekKey])) {
+                    $amount      = floatval($sale->amount);
+                    $openpayFee  = floatval($sale->openpay_fee);
+                    $platformFee = $amount * 0.10;
+                    $net         = max(0, $amount - $openpayFee - $platformFee);
+                    $incomeByWeek[$weekKey] += $net;
+                }
+            }
+            foreach ($incomeByWeek as $weekKey => $total) {
+                list($year, $weekNum) = explode('-', $weekKey);
+                $chartLabels[] = 'Semana ' . intval($weekNum);
+                $chartSeries[] = round((float) $total, 2);
+            }
+            return [
+                'labels' => $chartLabels,
+                'series' => $chartSeries,
+            ];
+        }
+        $incomeByMonth = [];
+        for ($m = 5; $m >= 0; $m--) {
+            $monthNum = (int) Carbon::now()->startOfMonth()->subMonths($m)->format('n');
+            $incomeByMonth[$monthNum] = 0;
+        }
+        $sixMonthsAgo = Carbon::now()->startOfMonth()->subMonths(5);
+        $salesLast6Months = ArtistSale::where('artist_id', $artistId)
+            ->where('event_status', ArtistSale::EVENT_STATUS_COMPLETED)
+            ->where('created_at', '>=', $sixMonthsAgo)
+            ->get();
+        foreach ($salesLast6Months as $sale) {
+            $monthNum = (int) Carbon::parse($sale->created_at)->format('n');
+            if (isset($incomeByMonth[$monthNum])) {
+                $amount      = floatval($sale->amount);
+                $openpayFee  = floatval($sale->openpay_fee);
+                $platformFee = $amount * 0.10;
+                $net         = max(0, $amount - $openpayFee - $platformFee);
+                $incomeByMonth[$monthNum] += $net;
+            }
+        }
+        foreach ($incomeByMonth as $month => $total) {
+            $chartLabels[] = $this->getMonthName((int) $month);
+            $chartSeries[] = round((float) $total, 2);
+        }
+        return [
+            'labels' => $chartLabels,
+            'series' => $chartSeries,
+        ];
+    }
+
+    public function getArtistsList()
+    {
+        try {
+            $artists = Artist::select('id', 'name', 'user_id', 'zone')
+                ->with('user:id,name')
+                ->orderBy('name', 'asc')
+                ->get()
+                ->map(function ($artist) {
+                    return [
+                        'id'    => $artist->id,
+                        'name'  => $artist->name ?? optional($artist->user)->name ?? 'Artista',
+                        'image' => $artist->image ?? '',
+                    ];
+                });
+            return response()->json([
+                'success' => true,
+                'data'    => $artists,
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+    public function getArtistStats(Request $request, $artistId)
+    {
+        try {
+            $artist = Artist::with(['user', 'musicalGenders'])->findOrFail($artistId);
+            $isActive = optional($artist->user)->account_status !== 'restricted';
+            $currentStart  = Carbon::now()->startOfMonth();
+            $currentEnd    = Carbon::now()->endOfMonth();
+            $previousStart = Carbon::now()->subMonth()->startOfMonth();
+            $previousEnd   = Carbon::now()->subMonth()->endOfMonth();
+            $currentRating  = ArtistRating::where('artist_id', $artistId)
+                ->whereBetween('created_at', [$currentStart, $currentEnd])
+                ->avg('rating') ?? 0;
+            $previousRating = ArtistRating::where('artist_id', $artistId)
+                ->whereBetween('created_at', [$previousStart, $previousEnd])
+                ->avg('rating') ?? 0;
+            $averageRating  = ArtistRating::where('artist_id', $artistId)->avg('rating') ?? 0;
+            $currentSales  = ArtistSale::where('artist_id', $artistId)
+                ->where('event_status', ArtistSale::EVENT_STATUS_COMPLETED)
+                ->whereBetween('created_at', [$currentStart, $currentEnd])
+                ->get();
+            $previousSales = ArtistSale::where('artist_id', $artistId)
+                ->where('event_status', ArtistSale::EVENT_STATUS_COMPLETED)
+                ->whereBetween('created_at', [$previousStart, $previousEnd])
+                ->get();
+            $allSales        = ArtistSale::where('artist_id', $artistId)->get();
+            $totalIncome     = $this->calculateNetIncome($allSales->where('event_status', ArtistSale::EVENT_STATUS_COMPLETED));
+            $completedEvents = $allSales->where('event_status', ArtistSale::EVENT_STATUS_COMPLETED)->count();
+            $totalContracts  = $allSales->count();
+            $currentIncome   = $this->calculateNetIncome($currentSales);
+            $previousIncome  = $this->calculateNetIncome($previousSales);
+            $currentEvents   = $currentSales->count();
+            $previousEvents  = $previousSales->count();
+            $currentContracts  = ArtistSale::where('artist_id', $artistId)
+                ->whereBetween('created_at', [$currentStart, $currentEnd])
+                ->count();
+            $previousContracts = ArtistSale::where('artist_id', $artistId)
+                ->whereBetween('created_at', [$previousStart, $previousEnd])
+                ->count();
+            $sanctionsCount   = UserSanction::where('user_id', $artist->user_id)->count();
+            $currentSanctions = UserSanction::where('user_id', $artist->user_id)
+                ->whereBetween('created_at', [$currentStart, $currentEnd])
+                ->count();
+            $filter    = $request->query('filter', 'Por mes');
+            $chartData = $this->getChartData($filter, $artistId);
+            $upcomingEvents = ArtistSale::where('artist_id', $artistId)
+                ->where('approval_status', ArtistSale::APPROVAL_STATUS_ACCEPTED)
+                ->where('event_status', ArtistSale::EVENT_STATUS_PENDING)
+                ->whereDate('event_date', '>=', Carbon::today())
+                ->orderBy('event_date', 'asc')
+                ->take(3)
+                ->get()
+                ->map(function ($event) {
+                    $date = Carbon::parse($event->event_date);
+                    return [
+                        'id'       => $event->id,
+                        'title'    => $event->customer_first_name
+                            ? 'Evento de ' . $event->customer_first_name
+                            : 'Evento',
+                        'location' => $event->customer_city ?? 'Por definir',
+                        'date'     => $date->format('d') . ' ' . $this->getMonthName((int) $date->format('n')),
+                        'status'   => $event->event_status,
+                    ];
+                });
+            return response()->json([
+                'success' => true,
+                'data'    => [
+                    'profile' => [
+                        'name'         => $artist->name ?? optional($artist->user)->name ?? 'Artista',
+                        'is_active'    => $isActive,
+                        'location'     => $artist->zone ?? 'No especificada',
+                        'member_since' => $this->formatDate($artist->created_at),
+                        'members'      => $artist->members ?? 1,
+                        'genders'      => $artist->musicalGenders->pluck('name'),
+                        'avatar'       => $artist->image ?? '',
+                        'socials'      => $artist->social_media ?? [],
+                    ],
+                    'kpis' => [
+                        'rating'          => round((float) $averageRating, 1),
+                        'income'          => number_format((float) $totalIncome, 2),
+                        'events'          => $completedEvents,
+                        'contracts'       => $totalContracts,
+                        'sanctions'       => $sanctionsCount,
+                        'rating_trend'    => $this->calcRatingTrend((float) $currentRating, (float) $previousRating),
+                        'income_trend'    => $this->calcIncomeTrend((float) $currentIncome, (float) $previousIncome),
+                        'events_trend'    => $this->calcTrend((float) $currentEvents, (float) $previousEvents, 'nuevos'),
+                        'hires_trend'     => $this->calcTrend((float) $currentContracts, (float) $previousContracts, 'nuevas'),
+                        'sanctions_trend' => $currentSanctions . ' nuevas',
+                    ],
+                    'chart'          => $chartData,
+                    'upcoming_events' => $upcomingEvents->values(),
+                ],
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/Admin/StatsController.php
+++ b/app/Http/Controllers/Admin/StatsController.php
@@ -26,13 +26,13 @@ class StatsController extends Controller
 
     private function formatDate(Carbon $date): string
     {
-        $day   = $date->format('d');
+        $day = $date->format('d');
         $month = $this->getMonthName((int) $date->format('n'));
-        $year  = $date->format('Y');
+        $year = $date->format('Y');
         return "{$day} de {$month} de {$year}";
     }
 
-    private function calcTrend(float $current, float $previous, string $suffix = 'nuevos'): string
+    private function calculateTrend(float $current, float $previous, string $suffix = 'nuevos'): string
     {
         if ($previous == 0 && $current == 0) {
             return 'Sin datos';
@@ -46,7 +46,7 @@ class StatsController extends Controller
         return $sign . ($change < 0 ? '-' : '') . $rounded . '%';
     }
 
-    private function calcRatingTrend(float $current, float $previous): string
+    private function calculateRatingTrend(float $current, float $previous): string
     {
         if ($previous == 0 && $current == 0) {
             return 'Sin datos';
@@ -59,7 +59,7 @@ class StatsController extends Controller
         return $sign . number_format($diff, 1) . ' pts';
     }
 
-    private function calcIncomeTrend(float $current, float $previous): string
+    private function calculateIncomeTrend(float $current, float $previous): string
     {
         if ($previous == 0 && $current == 0) {
             return 'Sin datos';
@@ -67,8 +67,8 @@ class StatsController extends Controller
         if ($previous == 0) {
             return '+$' . number_format($current, 2) . ' en el período';
         }
-        $change  = (($current - $previous) / $previous) * 100;
-        $sign    = $change >= 0 ? '+' : '';
+        $change = (($current - $previous) / $previous) * 100;
+        $sign = $change >= 0 ? '+' : '';
         $rounded = number_format(abs($change), 1);
         return $sign . ($change < 0 ? '-' : '') . $rounded . '%';
     }
@@ -76,8 +76,8 @@ class StatsController extends Controller
     private function calculateNetIncome($sales): float
     {
         return (float) $sales->sum(function ($sale) {
-            $amount      = floatval($sale->amount);
-            $openpayFee  = floatval($sale->openpay_fee);
+            $amount = floatval($sale->amount);
+            $openpayFee = floatval($sale->openpay_fee);
             $platformFee = $amount * 0.10;
             return max(0, $amount - $openpayFee - $platformFee);
         });
@@ -101,10 +101,10 @@ class StatsController extends Controller
             foreach ($salesLastWeeks as $sale) {
                 $weekKey = Carbon::parse($sale->created_at)->format('Y-W');
                 if (isset($incomeByWeek[$weekKey])) {
-                    $amount      = floatval($sale->amount);
-                    $openpayFee  = floatval($sale->openpay_fee);
+                    $amount = floatval($sale->amount);
+                    $openpayFee = floatval($sale->openpay_fee);
                     $platformFee = $amount * 0.10;
-                    $net         = max(0, $amount - $openpayFee - $platformFee);
+                    $net = max(0, $amount - $openpayFee - $platformFee);
                     $incomeByWeek[$weekKey] += $net;
                 }
             }
@@ -131,10 +131,10 @@ class StatsController extends Controller
         foreach ($salesLast6Months as $sale) {
             $monthNum = (int) Carbon::parse($sale->created_at)->format('n');
             if (isset($incomeByMonth[$monthNum])) {
-                $amount      = floatval($sale->amount);
-                $openpayFee  = floatval($sale->openpay_fee);
+                $amount = floatval($sale->amount);
+                $openpayFee = floatval($sale->openpay_fee);
                 $platformFee = $amount * 0.10;
-                $net         = max(0, $amount - $openpayFee - $platformFee);
+                $net = max(0, $amount - $openpayFee - $platformFee);
                 $incomeByMonth[$monthNum] += $net;
             }
         }
@@ -157,14 +157,14 @@ class StatsController extends Controller
                 ->get()
                 ->map(function ($artist) {
                     return [
-                        'id'    => $artist->id,
+                        'id' => $artist->id,
                         'name'  => $artist->name ?? optional($artist->user)->name ?? 'Artista',
                         'image' => $artist->image ?? '',
                     ];
                 });
             return response()->json([
                 'success' => true,
-                'data'    => $artists,
+                'data' => $artists,
             ], 200);
         } catch (\Exception $e) {
             return response()->json([
@@ -178,11 +178,11 @@ class StatsController extends Controller
         try {
             $artist = Artist::with(['user', 'musicalGenders'])->findOrFail($artistId);
             $isActive = optional($artist->user)->account_status !== 'restricted';
-            $currentStart  = Carbon::now()->startOfMonth();
-            $currentEnd    = Carbon::now()->endOfMonth();
+            $currentStart = Carbon::now()->startOfMonth();
+            $currentEnd = Carbon::now()->endOfMonth();
             $previousStart = Carbon::now()->subMonth()->startOfMonth();
-            $previousEnd   = Carbon::now()->subMonth()->endOfMonth();
-            $currentRating  = ArtistRating::where('artist_id', $artistId)
+            $previousEnd = Carbon::now()->subMonth()->endOfMonth();
+            $currentRating = ArtistRating::where('artist_id', $artistId)
                 ->whereBetween('created_at', [$currentStart, $currentEnd])
                 ->avg('rating') ?? 0;
             $previousRating = ArtistRating::where('artist_id', $artistId)
@@ -197,25 +197,25 @@ class StatsController extends Controller
                 ->where('event_status', ArtistSale::EVENT_STATUS_COMPLETED)
                 ->whereBetween('created_at', [$previousStart, $previousEnd])
                 ->get();
-            $allSales        = ArtistSale::where('artist_id', $artistId)->get();
-            $totalIncome     = $this->calculateNetIncome($allSales->where('event_status', ArtistSale::EVENT_STATUS_COMPLETED));
+            $allSales = ArtistSale::where('artist_id', $artistId)->get();
+            $totalIncome = $this->calculateNetIncome($allSales->where('event_status', ArtistSale::EVENT_STATUS_COMPLETED));
             $completedEvents = $allSales->where('event_status', ArtistSale::EVENT_STATUS_COMPLETED)->count();
-            $totalContracts  = $allSales->count();
-            $currentIncome   = $this->calculateNetIncome($currentSales);
-            $previousIncome  = $this->calculateNetIncome($previousSales);
-            $currentEvents   = $currentSales->count();
-            $previousEvents  = $previousSales->count();
-            $currentContracts  = ArtistSale::where('artist_id', $artistId)
+            $totalContracts = $allSales->count();
+            $currentIncome = $this->calculateNetIncome($currentSales);
+            $previousIncome = $this->calculateNetIncome($previousSales);
+            $currentEvents = $currentSales->count();
+            $previousEvents = $previousSales->count();
+            $currentContracts = ArtistSale::where('artist_id', $artistId)
                 ->whereBetween('created_at', [$currentStart, $currentEnd])
                 ->count();
             $previousContracts = ArtistSale::where('artist_id', $artistId)
                 ->whereBetween('created_at', [$previousStart, $previousEnd])
                 ->count();
-            $sanctionsCount   = UserSanction::where('user_id', $artist->user_id)->count();
+            $sanctionsCount = UserSanction::where('user_id', $artist->user_id)->count();
             $currentSanctions = UserSanction::where('user_id', $artist->user_id)
                 ->whereBetween('created_at', [$currentStart, $currentEnd])
                 ->count();
-            $filter    = $request->query('filter', 'Por mes');
+            $filter = $request->query('filter', 'Por mes');
             $chartData = $this->getChartData($filter, $artistId);
             $upcomingEvents = ArtistSale::where('artist_id', $artistId)
                 ->where('approval_status', ArtistSale::APPROVAL_STATUS_ACCEPTED)
@@ -227,41 +227,41 @@ class StatsController extends Controller
                 ->map(function ($event) {
                     $date = Carbon::parse($event->event_date);
                     return [
-                        'id'       => $event->id,
-                        'title'    => $event->customer_first_name
+                        'id' => $event->id,
+                        'title' => $event->customer_first_name
                             ? 'Evento de ' . $event->customer_first_name
                             : 'Evento',
                         'location' => $event->customer_city ?? 'Por definir',
-                        'date'     => $date->format('d') . ' ' . $this->getMonthName((int) $date->format('n')),
-                        'status'   => $event->event_status,
+                        'date' => $date->format('d') . ' ' . $this->getMonthName((int) $date->format('n')),
+                        'status' => $event->event_status,
                     ];
                 });
             return response()->json([
                 'success' => true,
-                'data'    => [
+                'data' => [
                     'profile' => [
-                        'name'         => $artist->name ?? optional($artist->user)->name ?? 'Artista',
-                        'is_active'    => $isActive,
-                        'location'     => $artist->zone ?? 'No especificada',
+                        'name' => $artist->name ?? optional($artist->user)->name ?? 'Artista',
+                        'is_active' => $isActive,
+                        'location' => $artist->zone ?? 'No especificada',
                         'member_since' => $this->formatDate($artist->created_at),
-                        'members'      => $artist->members ?? 1,
-                        'genders'      => $artist->musicalGenders->pluck('name'),
-                        'avatar'       => $artist->image ?? '',
-                        'socials'      => $artist->social_media ?? [],
+                        'members' => $artist->members ?? 1,
+                        'genders' => $artist->musicalGenders->pluck('name'),
+                        'avatar' => $artist->image ?? '',
+                        'socials' => $artist->social_media ?? [],
                     ],
                     'kpis' => [
-                        'rating'          => round((float) $averageRating, 1),
-                        'income'          => number_format((float) $totalIncome, 2),
-                        'events'          => $completedEvents,
-                        'contracts'       => $totalContracts,
-                        'sanctions'       => $sanctionsCount,
-                        'rating_trend'    => $this->calcRatingTrend((float) $currentRating, (float) $previousRating),
-                        'income_trend'    => $this->calcIncomeTrend((float) $currentIncome, (float) $previousIncome),
-                        'events_trend'    => $this->calcTrend((float) $currentEvents, (float) $previousEvents, 'nuevos'),
-                        'hires_trend'     => $this->calcTrend((float) $currentContracts, (float) $previousContracts, 'nuevas'),
+                        'rating' => round((float) $averageRating, 1),
+                        'income'=> number_format((float) $totalIncome, 2),
+                        'events' => $completedEvents,
+                        'contracts' => $totalContracts,
+                        'sanctions' => $sanctionsCount,
+                        'rating_trend' => $this->calculateRatingTrend((float) $currentRating, (float) $previousRating),
+                        'income_trend' => $this->calculateIncomeTrend((float) $currentIncome, (float) $previousIncome),
+                        'events_trend' => $this->calculateTrend((float) $currentEvents, (float) $previousEvents, 'nuevos'),
+                        'hires_trend'  => $this->calculateTrend((float) $currentContracts, (float) $previousContracts, 'nuevas'),
                         'sanctions_trend' => $currentSanctions . ' nuevas',
                     ],
-                    'chart'          => $chartData,
+                    'chart' => $chartData,
                     'upcoming_events' => $upcomingEvents->values(),
                 ],
             ], 200);

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,6 +36,7 @@ use App\Http\Controllers\Artist\ApprovalController;
 use App\Http\Controllers\Admin\UserSanctionController;
 use App\Http\Middleware\CheckAccountStatus;
 use App\Http\Controllers\WebhookController;
+use App\Http\Controllers\Admin\StatsController;
 
 // Routes for login without sesion
 Route::post('/login', [AuthController::class, 'login']);
@@ -63,6 +64,8 @@ Route::group(["middleware" => ["auth:api", CheckAccountStatus::class]], function
     Route::resource('/admin/permissions', PermissionsApiController::class);
     Route::resource('/admin/musical-genders', MusicalsGendersController::class);
     Route::get('/admin/dashboard-overview', [DashboardStatsController::class, 'index']);
+    Route::get('/admin/artists/list', [StatsController::class, 'getArtistsList']);
+    Route::get('/admin/artist-analytics/{artistId}', [StatsController::class, 'getArtistStats']);
     Route::get('/admin/payouts/pending', [AdminPayoutController::class, 'pendingPayouts']);
     Route::get('/admin/payouts/history', [AdminPayoutController::class, 'payoutHistory']);
     Route::post('/admin/payouts/{saleId}/release', [AdminPayoutController::class, 'releasePayout']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,7 +36,7 @@ use App\Http\Controllers\Artist\ApprovalController;
 use App\Http\Controllers\Admin\UserSanctionController;
 use App\Http\Middleware\CheckAccountStatus;
 use App\Http\Controllers\WebhookController;
-use App\Http\Controllers\Admin\StatsController;
+use App\Http\Controllers\Admin\ArtistStatsController;
 
 // Routes for login without sesion
 Route::post('/login', [AuthController::class, 'login']);
@@ -64,8 +64,8 @@ Route::group(["middleware" => ["auth:api", CheckAccountStatus::class]], function
     Route::resource('/admin/permissions', PermissionsApiController::class);
     Route::resource('/admin/musical-genders', MusicalsGendersController::class);
     Route::get('/admin/dashboard-overview', [DashboardStatsController::class, 'index']);
-    Route::get('/admin/artists/list', [StatsController::class, 'getArtistsList']);
-    Route::get('/admin/artist-analytics/{artistId}', [StatsController::class, 'getArtistStats']);
+    Route::get('/admin/artists/list', [ArtistStatsController::class, 'getArtistsList']);
+    Route::get('/admin/artist-analytics/{artistId}', [ArtistStatsController::class, 'getArtistStats']);
     Route::get('/admin/payouts/pending', [AdminPayoutController::class, 'pendingPayouts']);
     Route::get('/admin/payouts/history', [AdminPayoutController::class, 'payoutHistory']);
     Route::post('/admin/payouts/{saleId}/release', [AdminPayoutController::class, 'releasePayout']);


### PR DESCRIPTION
## Summary

### Admin Artist Analytics
- Added a new `StatsController` to provide artist analytics and reporting features for the admin panel.
- Implemented an endpoint to retrieve a simplified list of artists for selection:
  - `GET /admin/artists/list`
- Implemented an endpoint to retrieve detailed analytics for a specific artist:
  - `GET /admin/artist-analytics/{artistId}`

### Artist Statistics
- Added support for retrieving artist profile information, including:
  - Basic profile details
  - Musical genres
  - Social media links
  - Membership information
  - Account status

- Added KPI calculations for artists, including:
  - Average rating
  - Net income (after platform and payment processing fees)
  - Completed events
  - Total contracts
  - Total sanctions

### Trend Analysis
- Added month-over-month trend calculations for:
  - Ratings
  - Income
  - Completed events
  - Contracts
  - Sanctions

### Revenue Analytics
- Implemented net income calculations by subtracting platform and payment processing fees from completed sales.
- Added chart data generation with support for:
  - Weekly revenue
  - Monthly revenue

### Upcoming Events
- Added support for retrieving the next scheduled events for an artist, including event title, location, date, and status.

### API Routes
- Registered new admin API endpoints for artist listing and detailed artist analytics.