### PR TITLE
add ticket comments logic and separated user ticket endpoints

### DIFF
--- a/app/Http/Controllers/SupportTicketController.php
+++ b/app/Http/Controllers/SupportTicketController.php
@@ -72,7 +72,7 @@ class SupportTicketController extends Controller
         return response()->json(['message' => 'Evidencias guardadas'], 201);
     }
 
-    public function myTickets()
+    public function getTickets()
     {
         $tickets = SupportTicket::where('reporter_user_id', Auth::id())
             ->with(['artistSale.artist', 'artistSale.customer', 'reporter', 'media'])
@@ -81,7 +81,7 @@ class SupportTicketController extends Controller
         return response()->json(['data' => $tickets]);
     }
 
-    public function myArtistTickets()
+    public function getArtistTickets()
     {
         $userId = Auth::id();
         $tickets = SupportTicket::whereHas('artistSale.artist', function ($q) use ($userId) {
@@ -94,7 +94,7 @@ class SupportTicketController extends Controller
         return response()->json(['data' => $tickets]);
     }
 
-    public function myCustomerTickets()
+    public function getCustomerTickets()
     {
         $userId = Auth::id();
         $tickets = SupportTicket::whereHas('artistSale', function ($q) use ($userId) {
@@ -155,14 +155,14 @@ class SupportTicketController extends Controller
         ]);
     }
 
-    public function logs(SupportTicket $ticket)
+    public function getLogs(SupportTicket $ticket)
     {
         return response()->json([
             'data' => $ticket->logs()->get()
         ]);
     }
 
-    public function myTicketLogs(SupportTicket $ticket)
+    public function getTicketLogs(SupportTicket $ticket)
     {
         $userId = Auth::id();
         $sale = $ticket->artistSale()->with('artist')->first();

--- a/app/Http/Controllers/SupportTicketController.php
+++ b/app/Http/Controllers/SupportTicketController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
 use App\Models\TicketLog;
+use App\Models\User;
 
 class SupportTicketController extends Controller
 {
@@ -74,10 +75,35 @@ class SupportTicketController extends Controller
     public function myTickets()
     {
         $tickets = SupportTicket::where('reporter_user_id', Auth::id())
-            ->with(['artistSale.artist', 'media'])
+            ->with(['artistSale.artist', 'artistSale.customer', 'reporter', 'media'])
             ->latest()
             ->get();
+        return response()->json(['data' => $tickets]);
+    }
 
+    public function myArtistTickets()
+    {
+        $userId = Auth::id();
+        $tickets = SupportTicket::whereHas('artistSale.artist', function ($q) use ($userId) {
+                $q->where('user_id', $userId);
+            })
+            ->where('reporter_user_id', '!=', $userId)
+            ->with(['artistSale.artist', 'artistSale.customer', 'reporter', 'media'])
+            ->latest()
+            ->get();
+        return response()->json(['data' => $tickets]);
+    }
+
+    public function myCustomerTickets()
+    {
+        $userId = Auth::id();
+        $tickets = SupportTicket::whereHas('artistSale', function ($q) use ($userId) {
+                $q->where('customer_id', $userId);
+            })
+            ->where('reporter_user_id', '!=', $userId)
+            ->with(['artistSale.artist', 'artistSale.customer', 'reporter', 'media'])
+            ->latest()
+            ->get();
         return response()->json(['data' => $tickets]);
     }
 
@@ -138,12 +164,49 @@ class SupportTicketController extends Controller
 
     public function myTicketLogs(SupportTicket $ticket)
     {
-        if ($ticket->reporter_user_id !== Auth::id()) {
+        $userId = Auth::id();
+        $sale = $ticket->artistSale()->with('artist')->first();
+
+        $isAdmin = Auth::user() && Auth::user()->hasRole(User::ROLE_ADMIN);
+        $isReporter = $ticket->reporter_user_id === $userId;
+        $isArtist = $sale && $sale->artist && $sale->artist->user_id === $userId;
+        $isCustomer = $sale && $sale->customer_id === $userId;
+
+        if (!$isAdmin && !$isReporter && !$isArtist && !$isCustomer) {
             return response()->json(['message' => 'No autorizado'], 403);
         }
 
         return response()->json([
             'data' => $ticket->logs()->get()
         ]);
+    }
+
+    public function addComment(Request $request, SupportTicket $ticket)
+    {
+        $request->validate([
+            'message' => 'required|string|max:1000',
+        ]);
+        if (in_array($ticket->status, [SupportTicket::STATUS_RESOLVED, SupportTicket::STATUS_REJECTED])) {
+            return response()->json([
+                'message' => 'No es posible agregar comentarios a un ticket resuelto o rechazado.'
+            ], 422);
+        }
+        $userId = Auth::id();
+        $sale = $ticket->artistSale()->with('artist')->first();
+        $isAdmin = Auth::user() && Auth::user()->hasRole(User::ROLE_ADMIN);
+        $isCustomer = $sale && $sale->customer_id === $userId;
+        $isArtist = $sale && $sale->artist && $sale->artist->user_id === $userId;
+        $isReporter = $ticket->reporter_user_id === $userId;
+        if (!$isAdmin && !$isCustomer && !$isArtist && !$isReporter) {
+            return response()->json(['message' => 'No autorizado'], 403);
+        }
+        $log = TicketLog::create([
+            'support_ticket_id'  => $ticket->id,
+            'changed_by_user_id' => $userId,
+            'status' => $ticket->status,
+            'message' => $request->message,
+        ]);
+        $log->load('changedBy');
+        return response()->json(['data' => $log], 201);
     }
 }

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -40,7 +40,7 @@ class SupportTicket extends Model implements HasMedia
 
     public function logs()
     {
-        return $this->hasMany(TicketLog::class)->with('changedBy')->latest();
+        return $this->hasMany(TicketLog::class)->with('changedBy')->orderBy('created_at', 'asc');
     }
 
     public function sanction()

--- a/app/Models/TicketLog.php
+++ b/app/Models/TicketLog.php
@@ -17,6 +17,7 @@ class TicketLog extends Model
         'status',
         'resolution_type',
         'notes',
+        'message',
     ];
 
     public function supportTicket()

--- a/database/migrations/2026_07_29_203057_add_message_to_ticket_logs_table.php
+++ b/database/migrations/2026_07_29_203057_add_message_to_ticket_logs_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('ticket_logs', function (Blueprint $table) {
+            $table->text('message')->nullable()->after('notes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ticket_logs', function (Blueprint $table) {
+            $table->dropColumn('message');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -167,13 +167,17 @@ Route::group(["middleware" => ["auth:api", CheckAccountStatus::class]], function
     Route::get('/client/last-order', [PaymentController::class, 'getLastClientOrder']);
     Route::get('/artist/sales/details', [PaymentController::class, 'getArtistSalesDetails']);
     Route::post('/support-tickets', [SupportTicketController::class, 'store']);
-    Route::post('/support-tickets/{ticket}/evidences', [SupportTicketController::class, 'uploadEvidence']);
     Route::get('/support-tickets/my', [SupportTicketController::class, 'myTickets']);
+    Route::get('/support-tickets/my/artist', [SupportTicketController::class, 'myArtistTickets']);
+    Route::get('/support-tickets/my/customer', [SupportTicketController::class, 'myCustomerTickets']);
     Route::get('/support-tickets/{ticket}/logs', [SupportTicketController::class, 'myTicketLogs']);
+    Route::post('/support-tickets/{ticket}/evidences', [SupportTicketController::class, 'uploadEvidence']);
+    Route::post('/support-tickets/{ticket}/comment', [SupportTicketController::class, 'addComment']);
     Route::get('/admin/support-tickets', [SupportTicketController::class, 'index']);
     Route::get('/admin/support-tickets/{ticket}', [SupportTicketController::class, 'show']);
     Route::patch('/admin/support-tickets/{ticket}/status', [SupportTicketController::class, 'updateStatus']);
     Route::get('/admin/support-tickets/{ticket}/logs', [SupportTicketController::class, 'logs']);
+    Route::post('/admin/support-tickets/{ticket}/comment', [SupportTicketController::class, 'addComment']);
 });
 
 Route::post('/webhook/openpay', [WebhookController::class, 'handleOpenpay']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -167,16 +167,16 @@ Route::group(["middleware" => ["auth:api", CheckAccountStatus::class]], function
     Route::get('/client/last-order', [PaymentController::class, 'getLastClientOrder']);
     Route::get('/artist/sales/details', [PaymentController::class, 'getArtistSalesDetails']);
     Route::post('/support-tickets', [SupportTicketController::class, 'store']);
-    Route::get('/support-tickets/my', [SupportTicketController::class, 'myTickets']);
-    Route::get('/support-tickets/my/artist', [SupportTicketController::class, 'myArtistTickets']);
-    Route::get('/support-tickets/my/customer', [SupportTicketController::class, 'myCustomerTickets']);
-    Route::get('/support-tickets/{ticket}/logs', [SupportTicketController::class, 'myTicketLogs']);
+    Route::get('/support-tickets/my', [SupportTicketController::class, 'getTickets']);
+    Route::get('/support-tickets/my/artist', [SupportTicketController::class, 'getArtistTickets']);
+    Route::get('/support-tickets/my/customer', [SupportTicketController::class, 'getCustomerTickets']);
+    Route::get('/support-tickets/{ticket}/logs', [SupportTicketController::class, 'getTicketLogs']);
     Route::post('/support-tickets/{ticket}/evidences', [SupportTicketController::class, 'uploadEvidence']);
     Route::post('/support-tickets/{ticket}/comment', [SupportTicketController::class, 'addComment']);
     Route::get('/admin/support-tickets', [SupportTicketController::class, 'index']);
     Route::get('/admin/support-tickets/{ticket}', [SupportTicketController::class, 'show']);
     Route::patch('/admin/support-tickets/{ticket}/status', [SupportTicketController::class, 'updateStatus']);
-    Route::get('/admin/support-tickets/{ticket}/logs', [SupportTicketController::class, 'logs']);
+    Route::get('/admin/support-tickets/{ticket}/logs', [SupportTicketController::class, 'getLogs']);
     Route::post('/admin/support-tickets/{ticket}/comment', [SupportTicketController::class, 'addComment']);
 });
 


### PR DESCRIPTION
# Summary

## Support Ticket Enhancements
- Added support for artist and customer ticket retrieval through new endpoints.
- Expanded ticket responses to include reporter and customer relationship data.
- Improved ticket log access permissions to allow admins, reporters, artists, and customers involved in the ticket to view its history.

## Ticket Comments
- Added the ability to post comments on support tickets.
- Prevented comments from being added to resolved or rejected tickets.
- Stored comments as ticket log entries while preserving the current ticket status.
- Returned the comment author information after creating a new comment.

## Ticket Log Improvements
- Updated ticket logs to be returned in chronological order instead of reverse chronological order.
- Added support for a `message` field in the `TicketLog` model.

## API Updates
- Added new endpoints for:
  - Retrieving tickets assigned to the authenticated artist.
  - Retrieving tickets related to the authenticated customer.
  - Adding comments to support tickets.
  - Allowing administrators to add comments to support tickets.

## Database
- Added a new migration to include the `message` column in the `ticket_logs` table.