### PR TITLE
fix(payouts): adjust platform fee deduction logic for artist liquidat…

### DIFF
--- a/app/Http/Controllers/Admin/AdminPayoutController.php
+++ b/app/Http/Controllers/Admin/AdminPayoutController.php
@@ -28,9 +28,8 @@ class AdminPayoutController extends Controller
     private function calculateAdjustedNetPayout(ArtistSale $sale, bool $applyOpenpayFee = true): float
     {
         $amount = floatval($sale->amount);
-        $openpayFee = $applyOpenpayFee ? floatval($sale->openpay_fee) : 0;
         $platformFee = $amount * 0.10;
-        $netArtistPayout = $amount - $openpayFee - $platformFee;
+        $netArtistPayout = $amount - $platformFee;
 
         $penalties = EventCancellation::select('event_cancellations.penalty_amount')
             ->join('artist_sales', 'event_cancellations.artist_sale_id', '=', 'artist_sales.id')
@@ -71,7 +70,7 @@ class AdminPayoutController extends Controller
             $amount = floatval($sale->amount);
             $openpayFee = floatval($sale->openpay_fee);
             $platformFee = $amount * 0.10;
-            $netArtistPayout = $amount - $openpayFee - $platformFee;
+            $netArtistPayout = $amount - $platformFee;
 
             $artistId = $sale->artist_id;
             $penalties = collect($artistPenalties->get($artistId, []));


### PR DESCRIPTION
## Summary of Changes
This PR updates the liquidation and payout calculation logic for artist sales. Transactional gateway fees (OpenPay) are now entirely absorbed by the platform (Vibeer) instead of being deducted from the artist's payout.

## Key Updates
- **Payout Calculation:** The net payout for artists now deducts only the platform fee (10%).
- **Gateway Fee Handling:** OpenPay processing fees remain recorded for administrative auditing but are excluded from artist balance subtractions.
- **Adjusted Totals:** Penalty calculations and final balance transfers now compute directly against the revised artist subtotal.

## Testing Instructions
1. Retrieve a completed sale event eligible for liquidation.
2. Verify that `net_payout` equals `amount - platform_fee`.
3. Confirm that OpenPay processing fees do not reduce the final transferable amount.