### PR TITLE
Implement individual arrival time handling for multiple artist bookings

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -773,8 +773,10 @@ class PaymentController extends Controller
 
                 $artistId = (int) $element['artist_id'];
                 $hours    = isset($element['hours']) ? (int) $element['hours'] : 1;
-                $normalizedEventDate = $eventDate ? Carbon::parse($eventDate)->toDateString() : null;
-                $normalizedEventHour = $eventHour ? Carbon::parse($eventHour)->format('H:i:s') : null;
+                $itemEventDate = $element['event_date'] ?? $eventDate;
+                $itemEventHour = $element['event_hour'] ?? $eventHour;
+                $normalizedEventDate = $itemEventDate ? Carbon::parse($itemEventDate)->toDateString() : null;
+                $normalizedEventHour = $itemEventHour ? Carbon::parse($itemEventHour)->format('H:i:s') : null;
 
                 $artist = Artist::find($artistId);
                 if (!$artist) {


### PR DESCRIPTION
**Summary**

This PR updates the booking workflow to support individual arrival times when a client purchases multiple artists in a single order.

Instead of using a single arrival time for the entire purchase, each artist can now have their own arrival time, providing greater flexibility and ensuring event schedules are managed independently.

**Changes Implemented**

🔹 Booking Logic

- Added support for assigning an individual arrival time to each artist.
- Updated the payment workflow to process arrival times independently.
- Improved handling of multi-artist purchases.

🔹 Business Logic

- Removed the limitation of using a single arrival time for all artists.
- Ensured each booking stores the corresponding arrival time.
- Improved scheduling flexibility.

**📁 Files Modified**
Backend

Controllers

- app/Http/Controllers/PaymentController.php