### PR TITLE
update ArtistSalesSeeder to iterate by artists ensuring all get sales instead of grouping by clients

### DIFF
--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -14,8 +14,6 @@ class ArtistSalesSeeder extends Seeder
     {
         $this->call(ArtistPayoutMethodSeeder::class);
 
-        DB::statement('TRUNCATE TABLE artist_sales RESTART IDENTITY CASCADE;');
-
         $artistIds = DB::table('artists')->orderBy('id')->pluck('id')->all();
         $customers = User::whereHas('roles', function ($q) {
             $q->where('slug', User::ROLE_CLIENT);

--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -14,6 +14,8 @@ class ArtistSalesSeeder extends Seeder
     {
         $this->call(ArtistPayoutMethodSeeder::class);
 
+        DB::statement('TRUNCATE TABLE artist_sales RESTART IDENTITY CASCADE;');
+
         $artistIds = DB::table('artists')->orderBy('id')->pluck('id')->all();
         $customers = User::whereHas('roles', function ($q) {
             $q->where('slug', User::ROLE_CLIENT);
@@ -34,23 +36,25 @@ class ArtistSalesSeeder extends Seeder
             ArtistSale::EVENT_STATUS_EXPIRED,
         ];
 
-        foreach ($artistIds as $artistIndex => $artistId) {
-            for ($j = 0; $j < 1; $j++) {
-                $customer = $customers[($artistIndex + $j) % count($customers)];
-                $statusIndex = ($artistIndex + $j) % count($eventStatusCycle);
-                $eventStatus = $eventStatusCycle[$statusIndex];
+        $globalSaleCounter = 0;
+
+        foreach ($customers as $customerIndex => $customer) {
+            for ($j = 0; $j < count($eventStatusCycle); $j++) {
+                $artistId = $artistIds[$globalSaleCounter % count($artistIds)];
+                $globalSaleCounter++;
+                $eventStatus = $eventStatusCycle[$j];
                 $artistSaleIndex = $artistEventCounts[$artistId] ?? 0;
                 $artistEventCounts[$artistId] = $artistSaleIndex + 1;
 
-                $paymentMethod = $paymentMethods[($artistIndex + $j) % count($paymentMethods)];
+                $paymentMethod = $paymentMethods[($customerIndex + $j) % count($paymentMethods)];
 
-                $amount = $amounts[($artistIndex + $j) % count($amounts)];
+                $amount = $amounts[($customerIndex + $j) % count($amounts)];
                 $openpayFee = ($paymentMethod === 'card')
                     ? round(($amount * 0.029) * 1.16, 2)
                     : 0.00;
 
                 $eventDate = $this->buildEventDate($eventStatus, $artistSaleIndex);
-                $createdAt = Carbon::now()->addDays($createdAtOffsets[($artistIndex + $j) % count($createdAtOffsets)]);
+                $createdAt = Carbon::now()->addDays($createdAtOffsets[($customerIndex + $j) % count($createdAtOffsets)]);
 
                 $approvalStatus = $eventStatus === ArtistSale::EVENT_STATUS_PENDING
                     ? ArtistSale::APPROVAL_STATUS_PENDING

--- a/database/seeders/ArtistSalesSeeder.php
+++ b/database/seeders/ArtistSalesSeeder.php
@@ -34,22 +34,23 @@ class ArtistSalesSeeder extends Seeder
             ArtistSale::EVENT_STATUS_EXPIRED,
         ];
 
-        foreach ($customers as $customerIndex => $customer) {
-            for ($j = 0; $j < count($eventStatusCycle); $j++) {
-                $artistId = $artistIds[($customerIndex + $j) % count($artistIds)];
-                $eventStatus = $eventStatusCycle[$j];
+        foreach ($artistIds as $artistIndex => $artistId) {
+            for ($j = 0; $j < 1; $j++) {
+                $customer = $customers[($artistIndex + $j) % count($customers)];
+                $statusIndex = ($artistIndex + $j) % count($eventStatusCycle);
+                $eventStatus = $eventStatusCycle[$statusIndex];
                 $artistSaleIndex = $artistEventCounts[$artistId] ?? 0;
                 $artistEventCounts[$artistId] = $artistSaleIndex + 1;
 
-                $paymentMethod = $paymentMethods[($customerIndex + $j) % count($paymentMethods)];
+                $paymentMethod = $paymentMethods[($artistIndex + $j) % count($paymentMethods)];
 
-                $amount = $amounts[($customerIndex + $j) % count($amounts)];
+                $amount = $amounts[($artistIndex + $j) % count($amounts)];
                 $openpayFee = ($paymentMethod === 'card')
                     ? round(($amount * 0.029) * 1.16, 2)
                     : 0.00;
 
                 $eventDate = $this->buildEventDate($eventStatus, $artistSaleIndex);
-                $createdAt = Carbon::now()->addDays($createdAtOffsets[($customerIndex + $j) % count($createdAtOffsets)]);
+                $createdAt = Carbon::now()->addDays($createdAtOffsets[($artistIndex + $j) % count($createdAtOffsets)]);
 
                 $approvalStatus = $eventStatus === ArtistSale::EVENT_STATUS_PENDING
                     ? ArtistSale::APPROVAL_STATUS_PENDING


### PR DESCRIPTION
# Summary

- Updated the `ArtistSalesSeeder` generation logic to iterate over artists instead of customers.
- Ensured that every artist is assigned at least one generated sale, providing more consistent seed data across all artists.
- Adjusted customer assignment to rotate through the available customers while keeping one sale per artist.
- Updated event status, payment method, amount, and `createdAt` calculations to use the artist-based iteration indexes.
- Preserved the existing event status distribution and sale generation behavior while improving coverage of seeded sales.
- Fixed the previous limitation where sales were primarily distributed per customer, which could leave some artists without any sales in the seeded database.