### PR TITLE
filter cancellations by last sanction date to prevent double counting

### DIFF
--- a/app/Http/Controllers/Admin/UserSanctionController.php
+++ b/app/Http/Controllers/Admin/UserSanctionController.php
@@ -123,11 +123,20 @@ class UserSanctionController extends Controller
                 
                 $thirtyDaysAgo = Carbon::now()->subDays(self::FAULT_LOOKBACK_DAYS);
 
-                $cancellations = EventCancellation::where('user_id', $user->id)
+                $lastSanction = UserSanction::where('user_id', $user->id)
+                    ->latest('created_at')
+                    ->first();
+
+                $cancellationsQuery = EventCancellation::where('user_id', $user->id)
                     ->where('created_at', '>=', $thirtyDaysAgo) 
                     ->where('penalty_percentage', '>', 0)
-                    ->with('artistSale')
-                    ->get();
+                    ->with('artistSale');
+
+                if ($lastSanction) {
+                    $cancellationsQuery->where('created_at', '>', $lastSanction->created_at);
+                }
+
+                $cancellations = $cancellationsQuery->get();
                 $faults = 0;
                 
                 foreach($cancellations as $cancel) {
@@ -169,7 +178,6 @@ class UserSanctionController extends Controller
 
             return response()->json($users, 200);
         } catch (\Exception $e) {
-            DB::rollback();
             return response()->json([
                 'success' => false,
                 'message' => $e->getMessage()
@@ -230,7 +238,6 @@ class UserSanctionController extends Controller
             ], 200);
 
         } catch (\Exception $e) {
-            DB::rollback();
             return response()->json([
                 'success' => false,
                 'message' => $e->getMessage()
@@ -281,7 +288,6 @@ class UserSanctionController extends Controller
             ], 200);
 
         } catch (\Exception $e) {
-            DB::rollback();
             return response()->json([
                 'success' => false,
                 'message' => $e->getMessage()


### PR DESCRIPTION
## Backend Changes Summary

### User Sanction Logic
- Refactored the event cancellation query to build it incrementally before execution.
- Added support to retrieve the user's latest sanction and use it as a reference point.
- Limited cancellation counting to events that occurred after the user's most recent sanction.
- Preserved the existing 30-day lookback period and penalty percentage filters.
- Delayed query execution until all filtering conditions were applied, improving query flexibility.

### Error Handling
- Removed unnecessary `DB::rollback()` calls from exception handlers in methods that do not manage database transactions, simplifying error handling and avoiding redundant rollback attempts.