### PR TITLE
Add endpoint and permission for artists to view own stats

### DIFF
--- a/app/Http/Controllers/Admin/ArtistStatsController.php
+++ b/app/Http/Controllers/Admin/ArtistStatsController.php
@@ -177,7 +177,50 @@ class ArtistStatsController extends Controller
     {
         try {
             $artist = Artist::with(['user', 'musicalGenders'])->findOrFail($artistId);
-            $isActive = optional($artist->user)->account_status !== 'restricted';
+            return $this->buildArtistStatsResponse($artist, $request);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function getMyArtistStats(Request $request)
+    {
+        try {
+            $user = $request->user();
+            if (!$user) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Unauthenticated',
+                ], 401);
+            }
+
+            $artist = Artist::with(['user', 'musicalGenders'])
+                ->where('user_id', $user->id)
+                ->first();
+
+            if (!$artist) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Artist profile not found for this user',
+                ], 404);
+            }
+
+            return $this->buildArtistStatsResponse($artist, $request);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    private function buildArtistStatsResponse(Artist $artist, Request $request)
+    {
+        $artistId = $artist->id;
+        $isActive = optional($artist->user)->account_status !== 'restricted';
             $currentStart = Carbon::now()->startOfMonth();
             $currentEnd = Carbon::now()->endOfMonth();
             $previousStart = Carbon::now()->subMonth()->startOfMonth();
@@ -265,11 +308,5 @@ class ArtistStatsController extends Controller
                     'upcoming_events' => $upcomingEvents->values(),
                 ],
             ], 200);
-        } catch (\Exception $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ], 500);
-        }
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -56,6 +56,7 @@ class RoleSeeder extends Seeder
         Permission::create(['name' => 'Ver su perfil de artista', 'slug' => 'view-profile-artist', 'description' => 'Ver su perfil de artista'])->roles()->sync([2]);
         Permission::create(['name' => 'Crear perfil de artista', 'slug' => 'create-profile-artist', 'description' => 'Crear perfil de artista'])->roles()->sync([2]);
         Permission::create(['name' => 'Editar su perfil de artista', 'slug' => 'edit-profile-artist', 'description' => 'Editar su perfil de artista'])->roles()->sync([2]);
+        Permission::create(['name' => 'Ver sus propias estadísticas', 'slug' => 'view-own-artist-stats', 'description' => 'Ver el análisis y estadísticas de su propio perfil de artista'])->roles()->sync([2]);
         //Permission::create(['name' => 'Eliminar su perfil de artista', 'slug' => 'delete-profile-artist', 'description' => 'Eliminar su perfil de artista'])->roles()->sync([2]);
 
         //Ruta de Cliente

--- a/routes/api.php
+++ b/routes/api.php
@@ -84,6 +84,7 @@ Route::group(["middleware" => ["auth:api", CheckAccountStatus::class]], function
     Route::post('/admin/client-refunds/{id}/process', [ClientRefundController::class, 'processRefund']);
 
     //Route for artist
+    Route::get('/artist/my-analytics', [ArtistStatsController::class, 'getMyArtistStats']);
     Route::post('/artist-new/up-date/{id}', [ArtistController::class, 'updateDetails']);
     Route::get('/artist-new/gallery', [ArtistController::class, 'artistGalleryIndex']);
     Route::get('/artist-new/videos', [ArtistController::class, 'artistVideosIndex']);


### PR DESCRIPTION
## 📝 Description
This PR introduces a dedicated endpoint and permission allowing authenticated artist users to retrieve their own profile analytics and revenue statistics directly without requiring administrator privileges or explicitly passing an `artist_id`.

---

## 🚀 Key Changes

### 🔑 Permissions & Routes
- **`database/seeders/RoleSeeder.php`**:
  - Added new permission `view-own-artist-stats` assigned to the `artista` role (`role_id: 2`).
- **`routes/api.php`**:
  - Added route `GET /api/artist/my-analytics` mapped to `ArtistStatsController@getMyArtistStats`.

### 🎮 Controller Logic (`ArtistStatsController.php`)
- **`getMyArtistStats`**: Fetches the `Artist` model associated with `auth()->user()->id` and delegates processing.
- **`buildArtistStatsResponse`**: Refactored shared statistical generation logic (monthly earnings, upcoming events, performance breakdown) into a reusable private helper method.

---

## 🧪 Testing Checklist
- [ ] Authenticate as an artist and execute `GET /api/artist/my-analytics`.
- [ ] Confirm `404 Not Found` is returned if the user does not have an active artist record.
- [ ] Verify metrics calculated via `/api/artist/my-analytics` accurately match admin stats for the same artist.