### PR TITLE
Fix: Correct user sanction seeder and account lock records

### DIFF
--- a/database/seeders/UserSanctionSeeder.php
+++ b/database/seeders/UserSanctionSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\Artist;
 use App\Models\ArtistSale;
 use App\Models\EventCancellation;
 use App\Models\SupportTicket;
@@ -18,14 +17,8 @@ class UserSanctionSeeder extends Seeder
         $sale = ArtistSale::first();
         $adminUser = User::first();
 
-        $artistAccount = Artist::where('slug', 'charles-ans')->first()?->user;
-        $clientAccount = User::whereHas('roles', function ($query) {
-            $query->where('slug', User::ROLE_CLIENT);
-        })
-            ->where('id', '!=', $adminUser->id)
-            ->whereNotIn('email', ['alexis@gmail.com', 'fernando@gmail.com'])
-            ->orderBy('id')
-            ->first();
+        $artistAccount = User::where('email', 'miguel@gmail.com')->first();
+        $clientAccount = User::where('email', 'carlosramirez@gmail.com')->first();
 
         $targets = [
             'artista' => $artistAccount,

--- a/database/seeders/UserSanctionSeeder.php
+++ b/database/seeders/UserSanctionSeeder.php
@@ -93,14 +93,15 @@ class UserSanctionSeeder extends Seeder
 
     private function createCancellationHistory(User $user, string $role, string $reason)
     {
-        $sale = null;
-        if ($role === 'artista') {
-            $sale = ArtistSale::whereHas('artist', function ($query) use ($user) {
+        $saleQuery = match ($role) {
+            'artista' => ArtistSale::whereHas('artist', function ($query) use ($user) {
                 $query->where('user_id', $user->id);
-            })->orderBy('event_date')->first();
-        } else {
-            $sale = ArtistSale::where('customer_id', $user->id)->orderBy('event_date')->first();
-        }
+            })->orderBy('event_date'),
+            'cliente' => ArtistSale::where('customer_id', $user->id)->orderBy('event_date'),
+            default => null,
+        };
+
+        $sale = $saleQuery?->first();
 
         if (!$sale) {
             return;

--- a/database/seeders/UserSanctionSeeder.php
+++ b/database/seeders/UserSanctionSeeder.php
@@ -2,7 +2,9 @@
 
 namespace Database\Seeders;
 
+use App\Models\Artist;
 use App\Models\ArtistSale;
+use App\Models\EventCancellation;
 use App\Models\SupportTicket;
 use App\Models\User;
 use App\Models\UserSanction;
@@ -15,46 +17,46 @@ class UserSanctionSeeder extends Seeder
     {
         $sale = ArtistSale::first();
         $adminUser = User::first();
-        $candidates = User::has('roles')
+
+        $artistAccount = Artist::where('slug', 'charles-ans')->first()?->user;
+        $clientAccount = User::whereHas('roles', function ($query) {
+            $query->where('slug', User::ROLE_CLIENT);
+        })
             ->where('id', '!=', $adminUser->id)
-            ->inRandomOrder()
-            ->get();
-        $users = collect();
-        for ($i = 0; $i < 3; $i++) {
-            if (isset($candidates[$i])) {
-                $users->push($candidates[$i]);
-            }
-        }
-        if ($users->isEmpty() || !$sale || !$adminUser) {
+            ->whereNotIn('email', ['alexis@gmail.com', 'fernando@gmail.com'])
+            ->orderBy('id')
+            ->first();
+
+        $targets = [
+            'artista' => $artistAccount,
+            'cliente' => $clientAccount,
+        ];
+
+        $targets = array_filter($targets);
+
+        if (empty($targets) || !$sale || !$adminUser) {
             return;
         }
 
-        $sanctionsPattern = [
-            [
+        $sanctionByRole = [
+            'artista' => [
                 'type' => 'restricted',
                 'days' => 7,
                 'reason' => 'Uso de lenguaje inapropiado en el chat del evento.',
                 'source' => 'ticket',
                 'created_by' => 'admin',
             ],
-            [
+            'cliente' => [
                 'type' => 'restricted',
                 'days' => null,
                 'reason' => 'Intento de engaño al cliente fuera de la plataforma.',
                 'source' => 'ticket',
                 'created_by' => 'admin',
             ],
-            [
-                'type' => 'restricted',
-                'days' => 30,
-                'reason' => 'SISTEMA: Restricción automática por acumulación de faltas.',
-                'source' => 'expired_approval',
-                'created_by' => 'system',
-            ]
         ];
 
-        foreach ($users as $index => $user) {
-            $pattern = $sanctionsPattern[$index % count($sanctionsPattern)];
+        foreach ($targets as $role => $user) {
+            $pattern = $sanctionByRole[$role];
             $user->update(['account_status' => $pattern['type']]);
             $sanctionableType = null;
             $sanctionableId = null;
@@ -71,12 +73,8 @@ class UserSanctionSeeder extends Seeder
                 $sanctionableType = SupportTicket::class;
                 $sanctionableId = $ticket->id;
             }
-            if ($pattern['source'] === 'expired_approval') {
-                $sanctionableType = ArtistSale::class;
-                $sanctionableId = $sale->id;
-            }
             $endsAt = $pattern['days'] ? Carbon::now()->addDays($pattern['days']) : null;
-            $creator = $pattern['created_by'] === 'system' ? 'system' : (string) $adminUser->id;
+            $creator = (string) $adminUser->id;
 
             UserSanction::create([
                 'user_id' => $user->id,
@@ -88,6 +86,43 @@ class UserSanctionSeeder extends Seeder
                 'ends_at' => $endsAt,
                 'created_by' => $creator,
             ]);
+
+            $this->createCancellationHistory($user, $role, $pattern['reason']);
         }
+    }
+
+    private function createCancellationHistory(User $user, string $role, string $reason)
+    {
+        $sale = null;
+        if ($role === 'artista') {
+            $sale = ArtistSale::whereHas('artist', function ($query) use ($user) {
+                $query->where('user_id', $user->id);
+            })->orderBy('event_date')->first();
+        } else {
+            $sale = ArtistSale::where('customer_id', $user->id)->orderBy('event_date')->first();
+        }
+
+        if (!$sale) {
+            return;
+        }
+
+        $penaltyPercentage = 30;
+        $sale->event_date = Carbon::now()->addDays(4)->toDateString();
+        $sale->event_status = ArtistSale::EVENT_STATUS_CANCELLED;
+        $sale->approval_status = ArtistSale::APPROVAL_STATUS_CANCELLED;
+        $sale->approval_responded_at = Carbon::now();
+        $sale->save();
+
+        $cancellation = new EventCancellation([
+            'artist_sale_id' => $sale->id,
+            'user_id' => $user->id,
+            'cancellation_reason' => 'Cancelación registrada para historial: ' . $reason,
+            'penalty_percentage' => $penaltyPercentage,
+            'penalty_amount' => round(floatval($sale->amount) * ($penaltyPercentage / 100), 2),
+            'refunded_at' => null,
+            'penalty_paid' => true,
+        ]);
+        $cancellation->created_at = Carbon::now()->addMinute();
+        $cancellation->save();
     }
 }


### PR DESCRIPTION
**Summary**

Fixed the user sanction seeder so that cancellation history records are correctly loaded and updated the account lock records used by the seed data.

**Changes**

- Fixed the sanction seeder so cancellation history is correctly retrieved.
- Replaced the random account lock records with two specific records.
- Added one locked account for a client.
- Added one locked account for an artist.
- Improved the consistency of the sanction seed data.

**Modified Files**

- database/seeders/UserSanctionSeeder.php