### PR TITLE
implement partial penalty discounts in admin payouts and add coverageradius to artist seeder

### DIFF
--- a/app/Http/Controllers/Admin/AdminPayoutController.php
+++ b/app/Http/Controllers/Admin/AdminPayoutController.php
@@ -86,6 +86,9 @@ class AdminPayoutController extends Controller
             $penalties = $showPenalty ? $penalties : collect([]);
             $totalPenalties = $showPenalty ? $totalPenalties : 0;
             $adjustedNet = $showPenalty ? max(0, $netArtistPayout - $totalPenalties) : $netArtistPayout;
+            $penaltyExceedsPayout = $showPenalty && ($totalPenalties > $netArtistPayout);
+            $remainingPenalty = $penaltyExceedsPayout ? ($totalPenalties - $netArtistPayout) : 0;
+            $hasPendingPenalties = $showPenalty && ($totalPenalties > 0);
             $availableAt = $sale->event_date 
                 ? Carbon::parse($sale->event_date)->startOfDay()->addDays(3) 
                 : null;
@@ -101,6 +104,9 @@ class AdminPayoutController extends Controller
                 'net_artist_payout' => $netArtistPayout,
                 'total_penalties' => $totalPenalties,
                 'adjusted_net_payout' => $adjustedNet,
+                'penalty_exceeds_payout' => $penaltyExceedsPayout,
+                'remaining_penalty' => $remainingPenalty,
+                'has_pending_penalties' => $hasPendingPenalties,
                 'event_date' => $sale->event_date,
                 'event_hour' => $sale->event_hour,
                 'event_status' => $sale->event_status,
@@ -179,7 +185,45 @@ class AdminPayoutController extends Controller
         }
 
         DB::transaction(function () use ($sale, $adminId, $applyFee) {
-            $adjustedNetPayout = $this->calculateAdjustedNetPayout($sale, $applyFee);
+            $amount = floatval($sale->amount);
+            $openpayFee = $applyFee ? floatval($sale->openpay_fee) : 0;
+            $platformFee = $amount * 0.10;
+            $netArtistPayout = $amount - $openpayFee - $platformFee;
+            $penalties = EventCancellation::whereIn('artist_sale_id', function ($query) use ($sale) {
+                $query->select('id')
+                    ->from('artist_sales')
+                    ->where('artist_id', $sale->artist_id);
+            })
+                ->where('penalty_paid', false)
+                ->where('penalty_amount', '>', 0)
+                ->whereNotNull('penalty_amount')
+                ->orderBy('created_at', 'asc')
+                ->lockForUpdate()
+                ->get();
+            $remainingPayout = $netArtistPayout;
+            $coveredPenaltiesTotal = 0;
+            foreach ($penalties as $penalty) {
+                if ($remainingPayout <= 0) {
+                    break;
+                }
+                $penaltyAmount = floatval($penalty->penalty_amount);
+                if ($remainingPayout < $penaltyAmount) {
+                    $paidPenalty = $penalty->replicate();
+                    $paidPenalty->penalty_amount = $remainingPayout;
+                    $paidPenalty->penalty_paid = true;
+                    $paidPenalty->save();
+                    $penalty->penalty_amount = $penaltyAmount - $remainingPayout;
+                    $penalty->save();
+                    $coveredPenaltiesTotal += $remainingPayout;
+                    $remainingPayout = 0;
+                    break;
+                }
+                $penalty->penalty_paid = true;
+                $penalty->save();
+                $remainingPayout -= $penaltyAmount;
+                $coveredPenaltiesTotal += $penaltyAmount;
+            }
+            $adjustedNetPayout = max(0, $netArtistPayout - $coveredPenaltiesTotal);
 
             $sale->status = ArtistSale::PAYMENT_STATUS_LIQUIDATED;
             $sale->save();
@@ -191,16 +235,6 @@ class AdminPayoutController extends Controller
                 'amount' => $adjustedNetPayout,
                 'openpay_fee_applied' => $applyFee,
             ]);
-
-            EventCancellation::whereIn('artist_sale_id', function ($query) use ($sale) {
-                $query->select('id')
-                    ->from('artist_sales')
-                    ->where('artist_id', $sale->artist_id);
-            })
-                ->where('penalty_paid', false)
-                ->where('penalty_amount', '>', 0)
-                ->whereNotNull('penalty_amount')
-                ->update(['penalty_paid' => true]);
         });
 
         return response()->json([

--- a/database/seeders/ArtistSeeder.php
+++ b/database/seeders/ArtistSeeder.php
@@ -28,6 +28,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 10000,
             'extra_kilometre' => '85',
+            'coverage_radius' => 50,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -54,6 +55,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 15000,
             'extra_kilometre' => '45',
+            'coverage_radius' => 40,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -80,6 +82,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 12000,
             'extra_kilometre' => '60',
+            'coverage_radius' => 45,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -105,6 +108,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 8000,
             'extra_kilometre' => '50',
+            'coverage_radius' => 35,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -131,6 +135,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 6000,
             'extra_kilometre' => '30',
+            'coverage_radius' => 30,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -156,6 +161,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 9000,
             'extra_kilometre' => '35',
+            'coverage_radius' => 25,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -181,6 +187,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 10000,
             'extra_kilometre' => '55',
+            'coverage_radius' => 55,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -206,6 +213,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 13000,
             'extra_kilometre' => '50',
+            'coverage_radius' => 40,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -231,6 +239,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 15000,
             'extra_kilometre' => '40',
+            'coverage_radius' => 60,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -256,6 +265,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 25000,
             'extra_kilometre' => '65',
+            'coverage_radius' => 70,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -281,6 +291,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 35000,
             'extra_kilometre' => '80',
+            'coverage_radius' => 80,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -306,6 +317,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 30000,
             'extra_kilometre' => '90',
+            'coverage_radius' => 90,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -332,6 +344,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 45000,
             'extra_kilometre' => '35',
+            'coverage_radius' => 35,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -358,6 +371,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 25000,
             'extra_kilometre' => '50',
+            'coverage_radius' => 50,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),
@@ -384,6 +398,7 @@ class ArtistSeeder extends Seeder
             'zone' => 'Ciudad de México. Méx.',
             'price_hour' => 35000,
             'extra_kilometre' => '60',
+            'coverage_radius' => 65,
         ]);
         $artist->musicalGenders()->sync([
             rand(1, 3),


### PR DESCRIPTION
## Changes Summary

### `AdminPayoutController.php`

* Enhanced the artist payout calculation to properly handle **pending cancellation penalties**.
* Added tracking for:

  * `penalty_exceeds_payout`
  * `remaining_penalty`
  * `has_pending_penalties`
* Implemented penalty deduction directly during the payout liquidation process.
* Added logic to process unpaid penalties **in chronological order**.
* Added database row locking with `lockForUpdate()` to prevent inconsistent penalty updates during transactions.
* Implemented **partial penalty payments** when the artist's available payout is not enough to fully cover a penalty.
* Remaining unpaid penalty amounts are preserved for future payouts.
* Updated the final payout amount based on the penalties actually covered.
* Removed the previous behavior that marked **all pending penalties as paid** after a payout, preventing penalties from being incorrectly cleared. 

### `ArtistSeeder.php`

* Added the `coverage_radius` property to all seeded artist records.
* Configured different coverage radius values for each artist, ranging from **25 km to 90 km**.
* This provides realistic test data for the artist service/coverage area functionality. 

### Overall

* Improved the **artist payout and cancellation penalty system** by making penalty collection incremental and accurately tied to available payouts.
* Expanded artist seed data to support **coverage radius-based functionality**.
