### PR TITLE
Support multi-file upload in artist photo gallery

### DIFF
--- a/app/Http/Controllers/Artist/ArtistController.php
+++ b/app/Http/Controllers/Artist/ArtistController.php
@@ -8,6 +8,7 @@ use App\Models\ArtistProfileRequest;
 use App\Models\Manager;
 use App\Rules\ValidImageUpload;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use App\Rules\ValidSocialMedia;
@@ -375,38 +376,54 @@ class ArtistController extends Controller
     public function storeGaleryArtist(Request $request)
     {
         $request->validate([
-            'sub_files_paths' => ['required', 'file', 'max:1024', new ValidImageUpload()],
+            'sub_files_paths' => ['required'],
         ]);
     
         try {
             $artist = Artist::where('user_id', Auth::user()->id)->firstOrFail();
             $artistGalleryCount = $artist->getMedia('artist_gallery')->count();
     
-            if ($artistGalleryCount < 5) {
-                if ($request->hasFile('sub_files_paths')) {
-                    $uploadedFile = $request->file('sub_files_paths');
-    
-                    DB::beginTransaction();
-                    $media = $artist->addMedia($uploadedFile)->toMediaCollection('artist_gallery');
-                    DB::commit();
-
-                    return response()->json([
-                        'success' => true,
-                        'message' => 'Imagen almacenada',
-                        'artistGallery' => [
-                            'id' => $media->id,
-                            'file_name' => $media->file_name,
-                            'original_url' => $media->getUrl(),
-                        ],
-                    ], 201);
-                }
-            } else {
+            if ($artistGalleryCount >= 5) {
                 return response()->json([
                     'success' => false,
                     'message' => "Máximo de imágenes almacenadas"
                 ], 401);
             }
+
+            $files = $request->file('sub_files_paths');
+            if (!is_array($files)) {
+                $files = [$files];
+            }
+
+            $availableSlots = 5 - $artistGalleryCount;
+            if (count($files) > $availableSlots) {
+                return response()->json([
+                    'success' => false,
+                    'message' => "Solo puedes subir {$availableSlots} imagen(es) más. Máximo 5 en total."
+                ], 422);
+            }
+
+            $this->validateGalleryFiles($files);
+
+            DB::beginTransaction();
+            $savedGallery = [];
+            foreach ($files as $uploadedFile) {
+                $media = $artist->addMedia($uploadedFile)->toMediaCollection('artist_gallery');
+                $savedGallery[] = [
+                    'id' => $media->id,
+                    'file_name' => $media->file_name,
+                    'original_url' => $media->getUrl(),
+                ];
+            }
+            DB::commit();
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Imágenes almacenadas',
+                'artistGallery' => $savedGallery,
+            ], 201);
         } catch (\Exception $e) {
+            DB::rollBack();
             return response()->json([
                 'success' => false,
                 'message' => $e->getMessage()
@@ -423,42 +440,74 @@ class ArtistController extends Controller
     public function updateGaleryArtist(Request $request)
     {
         $request->validate([
-            'sub_files_paths' => ['required', 'file', 'max:1024', new ValidImageUpload()],
+            'sub_files_paths' => ['required'],
         ]);
     
         try {
             $artist = Artist::where('user_id', Auth::user()->id)->firstOrFail();
             $artistGalleryCount = $artist->getMedia('artist_gallery')->count();
     
-            if ($artistGalleryCount < 5) {
-                if ($request->hasFile('sub_files_paths')) {
-                    $uploadedFile = $request->file('sub_files_paths');
-    
-                    DB::beginTransaction();
-                    $media = $artist->addMedia($uploadedFile)->toMediaCollection('artist_gallery');
-                    DB::commit();
-
-                    return response()->json([
-                        'success' => true,
-                        'message' => 'Imagen actualizada',
-                        'artistGallery' => [
-                            'id' => $media->id,
-                            'file_name' => $media->file_name,
-                            'original_url' => $media->getUrl(),
-                        ],
-                    ], 201);
-                }
-            } else {
+            if ($artistGalleryCount >= 5) {
                 return response()->json([
                     'success' => false,
                     'message' => "Máximo de imágenes almacenadas"
                 ], 401);
             }
+
+            $files = $request->file('sub_files_paths');
+            if (!is_array($files)) {
+                $files = [$files];
+            }
+
+            $availableSlots = 5 - $artistGalleryCount;
+            if (count($files) > $availableSlots) {
+                return response()->json([
+                    'success' => false,
+                    'message' => "Solo puedes subir {$availableSlots} imagen(es) más. Máximo 5 en total."
+                ], 422);
+            }
+
+            $this->validateGalleryFiles($files);
+
+            DB::beginTransaction();
+            $savedGallery = [];
+            foreach ($files as $uploadedFile) {
+                $media = $artist->addMedia($uploadedFile)->toMediaCollection('artist_gallery');
+                $savedGallery[] = [
+                    'id' => $media->id,
+                    'file_name' => $media->file_name,
+                    'original_url' => $media->getUrl(),
+                ];
+            }
+            DB::commit();
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Imágenes actualizadas',
+                'artistGallery' => $savedGallery,
+            ], 201);
         } catch (\Exception $e) {
+            DB::rollBack();
             return response()->json([
                 'success' => false,
                 'message' => $e->getMessage()
             ], 401);
+        }
+    }
+
+    private function validateGalleryFiles(array $files)
+    {
+        foreach ($files as $file) {
+            if (!$file instanceof UploadedFile || !$file->isValid()) {
+                throw new \InvalidArgumentException('Uno de los archivos no es una imagen válida.');
+            }
+            if ($file->getSize() > 1048576) {
+                throw new \InvalidArgumentException("La imagen \"{$file->getClientOriginalName()}\" supera el peso máximo de 1 MB.");
+            }
+            $rule = new ValidImageUpload();
+            if (!$rule->passes('sub_files_paths', $file)) {
+                throw new \InvalidArgumentException($rule->message());
+            }
         }
     }
     /**


### PR DESCRIPTION
## 📝 Description
This PR updates the artist photo gallery backend so the store/update endpoints accept multiple images in a single request, with per-file validation and an all-or-nothing transactional save.

---

## 🎨 Key Changes

### 🖼️ Multi-Image Handling (\ArtistController.php\)
- \storeGaleryArtist\ and \updateGaleryArtist\ now accept an array of files in \sub_files_paths\ (sent as \sub_files_paths[]\ from the client).
- Added \alidateGalleryFiles()\ which validates every file individually via \UploadedFile\, enforcing the 1 MB weight limit and the \ValidImageUpload\ rule (JPG/JPEG/PNG, horizontal orientation).
- Enforced the maximum of 5 images total, checking available slots before saving and returning a clear message when the limit would be exceeded.
- Files are saved in a loop inside a \DB::transaction\ (commit all/rollback all), so a failure leaves no orphan media records.
- The response includes the saved media list as \rtistGallery\.

---

## 🧪 Testing Checklist
- [ ] Upload 5 images at once; confirm all 5 are stored and returned in \rtistGallery\.
- [ ] Attempt to upload more than the available slots; confirm the limit message and 422 response.
- [ ] Upload an invalid file (wrong format, portrait, or over 1 MB); confirm the request is rejected with a clear message.