### PR TITLE
add total cancellations count and compute severity flags for user sanction history

### DIFF
--- a/app/Http/Controllers/Admin/UserSanctionController.php
+++ b/app/Http/Controllers/Admin/UserSanctionController.php
@@ -157,6 +157,9 @@ class UserSanctionController extends Controller
                 }
 
                 $user->faults_count = $faults; 
+                $user->total_cancellations_count = EventCancellation::where('user_id', $user->id)
+                    ->where('penalty_percentage', '>', 0)
+                    ->count();
                 
                 $statusWeight = 0;
                 if ($user->account_status == 'restricted') {
@@ -231,6 +234,19 @@ class UserSanctionController extends Controller
                 ->with('artistSale')
                 ->orderBy('id', 'desc')
                 ->get();
+
+            $cancellations->transform(function ($cancel) use ($user) {
+                if (!empty($cancel->artistSale)) {
+                    $eDate = \Carbon\Carbon::parse($cancel->artistSale->event_date)->startOfDay();
+                    $cDate = \Carbon\Carbon::parse($cancel->created_at)->startOfDay();
+                    $diff = $cDate->diffInDays($eDate, false);
+                    $cancel->days_difference = $diff;
+                    $cancel->is_direct_sanction = ($diff >= self::DIRECT_SANCTION_MIN_DAYS && $diff <= self::DIRECT_SANCTION_MAX_DAYS);
+                    $cancel->is_accumulated_fault = ($diff >= self::FAULT_ACCUMULATION_MIN_DAYS && $diff <= self::FAULT_ACCUMULATION_MAX_DAYS);
+                    $cancel->fault_threshold = ($cancel->artistSale->customer_id === $user->id) ? self::FAULT_THRESHOLD_CUSTOMER : self::FAULT_THRESHOLD_ARTIST;
+                }
+                return $cancel;
+            });
 
             return response()->json([
                 'success' => true,


### PR DESCRIPTION
# Changes Summary

## Payout Penalty & Cancellation Tracking Enhancements

* Added a new `total_cancellations_count` property to each user, counting cancellations that have a penalty percentage greater than `0`.
* Added cancellation date analysis to calculate the number of days between the event date and the cancellation date.
* Added a `days_difference` property to each cancellation record.
* Added `is_direct_sanction` to identify cancellations that fall within the configured direct-sanction period.
* Added `is_accumulated_fault` to identify cancellations that fall within the configured fault-accumulation period.
* Added `fault_threshold` to determine the applicable fault threshold based on whether the user is the customer or artist associated with the event.
* Used the existing sanction-related constants to keep cancellation classification consistent with the application's penalty rules.
* Applied the new cancellation metadata through the `$cancellations->transform()` process before returning the API response.

## Result

These changes improve the **user sanction and payout-penalty logic** by providing more detailed cancellation information and automatically determining whether each cancellation contributes to a direct sanction or accumulated faults.
