### PR TITLE
feat(offers): include original/discounted price in offers index

### DIFF
--- a/app/Http/Controllers/Artist/OfferController.php
+++ b/app/Http/Controllers/Artist/OfferController.php
@@ -18,11 +18,16 @@ class OfferController extends Controller
             $artist = Artist::where('user_id', Auth::user()->id)->firstOrFail();
             $offers = Offer::where('artist_id', $artist->id)->orderBy('created_at', 'desc')->get();
 
-            $offers->each(function ($offer) {
+            $offers->each(function ($offer) use ($artist) {
                 $offer->has_pending_sale = ArtistSale::where('offer_id', $offer->id)
                     ->where('approval_status', ArtistSale::APPROVAL_STATUS_PENDING)
                     ->exists();
                 $offer->is_active = now()->between($offer->start_date, $offer->end_date);
+                $priceHour = (float) $artist->price_hour;
+                $discount = (float) $offer->discount_percentage / 100;
+                $offer->original_price = round($priceHour, 2);
+                $offer->discounted_price = round($priceHour * (1 - $discount), 2);
+                $offer->saved_amount = round($priceHour * $discount, 2);
             });
 
             return response()->json(['success' => true, 'offers' => $offers], 200);


### PR DESCRIPTION
## Summary of Changes
OfferController::index now enriches each offer with computed price fields derived from the artist's price_hour and the offer's discount, so the frontend can display the before/after comparison in "Mis Ofertas".

## Key Updates
- Added original_price: the artist's base hourly price.
- Added discounted_price: hourly price after applying the discount (price_hour x (1 - discount%)).
- Added saved_amount: the monetary difference (price_hour x discount%).

## Verification
- Math matches discountedPrice already used in MusicalGenders/show.vue.