### PR TITLE
fix(support-tickets): restrict ticket categories by user role and fix…

### DIFF
--- a/app/Http/Controllers/SupportTicketController.php
+++ b/app/Http/Controllers/SupportTicketController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
 use App\Models\TicketLog;
 use App\Models\User;
+use Illuminate\Validation\Rule;
 
 class SupportTicketController extends Controller
 {
@@ -15,7 +16,7 @@ class SupportTicketController extends Controller
     {
         $request->validate([
             'artist_sale_id' => 'required|exists:artist_sales,id',
-            'category'       => 'required|in:no_show,delay,bad_service,cancellation,other',
+            'category'       => 'required|string',
             'description'    => 'required|string|min:10',
         ]);
 
@@ -28,6 +29,14 @@ class SupportTicketController extends Controller
         if (!$isCustomer && !$isArtist) {
             return response()->json(['message' => 'No autorizado'], 403);
         }
+
+        $allowedCategories = $isArtist
+            ? ['cancellation', 'other']
+            : ['no_show', 'delay', 'bad_service', 'cancellation', 'other'];
+
+        $request->validate([
+            'category' => ['required', Rule::in($allowedCategories)],
+        ]);
 
         if (now()->lt(Carbon::parse($sale->event_date))) {
             return response()->json([

--- a/database/seeders/SupportTicketSeeder.php
+++ b/database/seeders/SupportTicketSeeder.php
@@ -17,7 +17,8 @@ class SupportTicketSeeder extends Seeder
     {
         DB::statement('TRUNCATE TABLE ticket_logs, support_tickets RESTART IDENTITY CASCADE;');
 
-        $categories = ['no_show', 'delay', 'bad_service', 'cancellation', 'other'];
+        $clientCategories = ['no_show', 'delay', 'bad_service', 'cancellation', 'other'];
+        $artistCategories = ['cancellation', 'other'];
         $statuses = [
             SupportTicket::STATUS_OPEN,
             SupportTicket::STATUS_UNDER_REVIEW,
@@ -34,8 +35,8 @@ class SupportTicketSeeder extends Seeder
         $artistLimit = max(1, intdiv($artists->count(), 2));
         $clientLimit = max(1, intdiv($clients->count(), 2));
 
-        $this->createArtistTickets($artists->take($artistLimit), $categories, $statuses, $resolutionTypes);
-        $this->createClientTickets($clients->take($clientLimit), $categories, $statuses, $resolutionTypes);
+        $this->createArtistTickets($artists->take($artistLimit), $artistCategories, $statuses, $resolutionTypes);
+        $this->createClientTickets($clients->take($clientLimit), $clientCategories, $statuses, $resolutionTypes);
     }
 
     private function createArtistTickets($artists, array $categories, array $statuses, array $resolutionTypes)


### PR DESCRIPTION
## Summary of Changes
Fixed an issue where artists could view or create inconsistent support tickets (e.g., an artist reporting themselves for "no-show").

### Key Changes
- **`SupportTicketSeeder.php`**: Separated category arrays by user role. Artists are now seeded only with valid categories (`cancellation`, `other`), preventing invalid test data generation.
- **`SupportTicketController.php`**: Added dynamic validation in the `store` endpoint using `Rule::in()`. Allowed categories are now strictly evaluated based on whether the reporter is an artist or a customer.

## Testing & Verification
- Executed `kool run db-reset` / `php artisan db:seed` successfully.
- Verified in the frontend that the "Tickets I Created" tab under "My Reports" no longer displays invalid categories for artist accounts.