### PR TITLE
Add pending client refunds endpoint for admin

### DIFF
--- a/app/Http/Controllers/ClientRefundController.php
+++ b/app/Http/Controllers/ClientRefundController.php
@@ -27,6 +27,23 @@ class ClientRefundController extends Controller
         return response()->json($refunds, 200);
     }
 
+    public function pending()
+    {
+        $refunds = ClientRefund::with([
+            'cancellation.artistSale',
+            'customer',
+            'authorizedBy'
+        ])
+            ->where('status', ClientRefund::STATUS_PENDING)
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        return response()->json([
+            'success' => true,
+            'data' => $refunds
+        ], 200);
+    }
+
     public function processRefund(Request $request, $id)
     {
         $refund = ClientRefund::with(['cancellation.artistSale.artist', 'cancellation.artistSale.customer', 'customer'])->findOrFail($id);

--- a/app/Http/Controllers/ClientRefundController.php
+++ b/app/Http/Controllers/ClientRefundController.php
@@ -27,7 +27,7 @@ class ClientRefundController extends Controller
         return response()->json($refunds, 200);
     }
 
-    public function pending()
+    public function getPendingRefunds()
     {
         $refunds = ClientRefund::with([
             'cancellation.artistSale',

--- a/routes/api.php
+++ b/routes/api.php
@@ -81,7 +81,7 @@ Route::group(["middleware" => ["auth:api", CheckAccountStatus::class]], function
     Route::put('/admin/artist-approvals/{id}/accept', [ArtistApprovalController::class, 'accept']);
     Route::put('/admin/artist-approvals/{id}/reject', [ArtistApprovalController::class, 'reject']);
     Route::get('/admin/client-refunds', [ClientRefundController::class, 'index']);
-    Route::get('/admin/client-refunds/pending', [ClientRefundController::class, 'pending']);
+    Route::get('/admin/client-refunds/pending', [ClientRefundController::class, 'getPendingRefunds']);
     Route::post('/admin/client-refunds/{id}/process', [ClientRefundController::class, 'processRefund']);
 
     //Route for artist

--- a/routes/api.php
+++ b/routes/api.php
@@ -81,6 +81,7 @@ Route::group(["middleware" => ["auth:api", CheckAccountStatus::class]], function
     Route::put('/admin/artist-approvals/{id}/accept', [ArtistApprovalController::class, 'accept']);
     Route::put('/admin/artist-approvals/{id}/reject', [ArtistApprovalController::class, 'reject']);
     Route::get('/admin/client-refunds', [ClientRefundController::class, 'index']);
+    Route::get('/admin/client-refunds/pending', [ClientRefundController::class, 'pending']);
     Route::post('/admin/client-refunds/{id}/process', [ClientRefundController::class, 'processRefund']);
 
     //Route for artist


### PR DESCRIPTION
Adds GET /admin/client-refunds/pending returning only refunds with status pending, mirroring the pattern used by payouts and artist approvals pending endpoints. Backs the new badge counter in the admin sidebar.