### PR TITLE
Fix support tickets module

### DIFF
--- a/app/Http/Controllers/SupportTicketController.php
+++ b/app/Http/Controllers/SupportTicketController.php
@@ -166,7 +166,7 @@ class SupportTicketController extends Controller
         $previousStatus = $ticket->status;
 
         $ticket->update([
-            'status'          => $request->status,
+            'status' => $request->status,
             'resolution_type' => $isClosing ? $request->resolution_type : null,
         ]);
 

--- a/app/Http/Controllers/SupportTicketController.php
+++ b/app/Http/Controllers/SupportTicketController.php
@@ -119,13 +119,14 @@ class SupportTicketController extends Controller
     public function index(Request $request)
     {
         $request->validate([
-            'status'   => ['nullable', Rule::in([
+            'status'        => ['nullable', Rule::in([
                 SupportTicket::STATUS_OPEN,
                 SupportTicket::STATUS_UNDER_REVIEW,
                 SupportTicket::STATUS_RESOLVED,
                 SupportTicket::STATUS_REJECTED,
             ])],
-            'category' => ['nullable', Rule::in(SupportTicket::CATEGORIES_CUSTOMER)],
+            'category'      => ['nullable', Rule::in(SupportTicket::CATEGORIES_CUSTOMER)],
+            'reporter_role' => ['nullable', Rule::in(['artista', 'cliente'])],
         ]);
 
         $query = SupportTicket::with(['artistSale.artist', 'artistSale.customer', 'reporter.roles', 'media'])
@@ -136,6 +137,11 @@ class SupportTicketController extends Controller
         }
         if ($request->category) {
             $query->where('category', $request->category);
+        }
+        if ($request->reporter_role) {
+            $query->whereHas('reporter.roles', function ($q) use ($request) {
+                $q->where('slug', $request->reporter_role);
+            });
         }
 
         return response()->json(['data' => $query->paginate(15)]);

--- a/app/Http/Controllers/SupportTicketController.php
+++ b/app/Http/Controllers/SupportTicketController.php
@@ -15,9 +15,9 @@ class SupportTicketController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'artist_sale_id' => 'required|exists:artist_sales,id',
+            'artist_sale_id' => 'required|integer|exists:artist_sales,id',
             'category'       => 'required|string',
-            'description'    => 'required|string|min:10',
+            'description'    => 'required|string|min:10|max:2000',
         ]);
 
         $userId = Auth::id();
@@ -31,8 +31,8 @@ class SupportTicketController extends Controller
         }
 
         $allowedCategories = $isArtist
-            ? ['cancellation', 'other']
-            : ['no_show', 'delay', 'bad_service', 'cancellation', 'other'];
+            ? SupportTicket::CATEGORIES_ARTIST
+            : SupportTicket::CATEGORIES_CUSTOMER;
 
         $request->validate([
             'category' => ['required', Rule::in($allowedCategories)],
@@ -84,7 +84,7 @@ class SupportTicketController extends Controller
     public function getTickets()
     {
         $tickets = SupportTicket::where('reporter_user_id', Auth::id())
-            ->with(['artistSale.artist', 'artistSale.customer', 'reporter', 'media'])
+            ->with(['artistSale.artist', 'artistSale.customer', 'reporter.roles', 'media'])
             ->latest()
             ->get();
         return response()->json(['data' => $tickets]);
@@ -97,7 +97,7 @@ class SupportTicketController extends Controller
                 $q->where('user_id', $userId);
             })
             ->where('reporter_user_id', '!=', $userId)
-            ->with(['artistSale.artist', 'artistSale.customer', 'reporter', 'media'])
+            ->with(['artistSale.artist', 'artistSale.customer', 'reporter.roles', 'media'])
             ->latest()
             ->get();
         return response()->json(['data' => $tickets]);
@@ -110,7 +110,7 @@ class SupportTicketController extends Controller
                 $q->where('customer_id', $userId);
             })
             ->where('reporter_user_id', '!=', $userId)
-            ->with(['artistSale.artist', 'artistSale.customer', 'reporter', 'media'])
+            ->with(['artistSale.artist', 'artistSale.customer', 'reporter.roles', 'media'])
             ->latest()
             ->get();
         return response()->json(['data' => $tickets]);
@@ -118,7 +118,17 @@ class SupportTicketController extends Controller
 
     public function index(Request $request)
     {
-        $query = SupportTicket::with(['artistSale.artist', 'artistSale.customer', 'reporter', 'media'])
+        $request->validate([
+            'status'   => ['nullable', Rule::in([
+                SupportTicket::STATUS_OPEN,
+                SupportTicket::STATUS_UNDER_REVIEW,
+                SupportTicket::STATUS_RESOLVED,
+                SupportTicket::STATUS_REJECTED,
+            ])],
+            'category' => ['nullable', Rule::in(SupportTicket::CATEGORIES_CUSTOMER)],
+        ]);
+
+        $query = SupportTicket::with(['artistSale.artist', 'artistSale.customer', 'reporter.roles', 'media'])
             ->latest();
 
         if ($request->status) {
@@ -134,33 +144,43 @@ class SupportTicketController extends Controller
     public function show(SupportTicket $ticket)
     {
         return response()->json([
-            'data' => $ticket->load(['artistSale.artist', 'artistSale.customer', 'reporter', 'media'])
+            'data' => $ticket->load(['artistSale.artist', 'artistSale.customer', 'reporter.roles', 'media'])
         ]);
     }
 
     public function updateStatus(Request $request, SupportTicket $ticket)
     {
+        $isClosing = in_array($request->status, [SupportTicket::STATUS_RESOLVED, SupportTicket::STATUS_REJECTED], true);
+
         $request->validate([
-            'status' => 'required|in:open,under_review,resolved,rejected',
-            'resolution_type' => 'nullable|in:full_refund,partial_refund,no_action',
+            'status'          => ['required', Rule::in([
+                SupportTicket::STATUS_OPEN,
+                SupportTicket::STATUS_UNDER_REVIEW,
+                SupportTicket::STATUS_RESOLVED,
+                SupportTicket::STATUS_REJECTED,
+            ])],
+            'resolution_type' => [$isClosing ? 'required' : 'nullable', Rule::in(SupportTicket::RESOLUTION_TYPES)],
             'notes'           => 'nullable|string|max:500',
         ]);
 
+        $previousStatus = $ticket->status;
+
         $ticket->update([
-            'status' => $request->status,
-            'resolution_type' => $request->resolution_type,
+            'status'          => $request->status,
+            'resolution_type' => $isClosing ? $request->resolution_type : null,
         ]);
 
         TicketLog::create([
             'support_ticket_id'  => $ticket->id,
             'changed_by_user_id' => Auth::id(),
             'status'             => $request->status,
-            'resolution_type'    => $request->resolution_type,
-            'notes'              => $request->notes,
+            'resolution_type'    => $ticket->resolution_type,
+            'notes'              => $request->notes
+                ?? ($previousStatus !== $request->status ? "Estado actualizado de {$previousStatus} a {$request->status}." : null),
         ]);
 
         return response()->json([
-            'data' => $ticket->load(['artistSale.artist', 'artistSale.customer', 'reporter', 'media'])
+            'data' => $ticket->load(['artistSale.artist', 'artistSale.customer', 'reporter.roles', 'media'])
         ]);
     }
 

--- a/app/Models/SupportTicket.php
+++ b/app/Models/SupportTicket.php
@@ -14,6 +14,29 @@ class SupportTicket extends Model implements HasMedia
     const STATUS_RESOLVED = 'resolved';
     const STATUS_REJECTED = 'rejected';
 
+    const CATEGORY_NO_SHOW = 'no_show';
+    const CATEGORY_DELAY = 'delay';
+    const CATEGORY_BAD_SERVICE = 'bad_service';
+    const CATEGORY_CANCELLATION = 'cancellation';
+    const CATEGORY_OTHER = 'other';
+
+    const CATEGORIES_CUSTOMER = [
+        self::CATEGORY_NO_SHOW,
+        self::CATEGORY_DELAY,
+        self::CATEGORY_BAD_SERVICE,
+        self::CATEGORY_CANCELLATION,
+        self::CATEGORY_OTHER,
+    ];
+
+    const CATEGORIES_ARTIST = [
+        self::CATEGORY_NO_SHOW,
+        self::CATEGORY_BAD_SERVICE,
+        self::CATEGORY_CANCELLATION,
+        self::CATEGORY_OTHER,
+    ];
+
+    const RESOLUTION_TYPES = ['full_refund', 'partial_refund', 'no_action'];
+
     protected $fillable = [
         'artist_sale_id',
         'reporter_user_id',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -62,11 +62,16 @@ class User extends Authenticatable implements JWTSubject, MustVerifyEmail, HasMe
         'email_verified_at' => 'datetime',
     ];
 
-    protected $appends = ['image_profile'];
+    protected $appends = ['image_profile', 'role'];
 
     public function getImageProfileAttribute()
     {
         return $this->getFirstMediaUrl('profile_images');
+    }
+
+    public function getRoleAttribute()
+    {
+        return $this->roles->pluck('slug')->toArray();
     }
 
     public function registerMediaCollections(): void

--- a/database/seeders/SupportTicketSeeder.php
+++ b/database/seeders/SupportTicketSeeder.php
@@ -46,7 +46,7 @@ class SupportTicketSeeder extends Seeder
                     $found,
                     $artist->user_id,
                     $category,
-                    $this->artistStatusFor($artistSeq),
+                    $this->getArtistStatus($artistSeq),
                     $adminId,
                     $artistSeq,
                     $this->getArtistDescriptions()[$category],
@@ -67,7 +67,7 @@ class SupportTicketSeeder extends Seeder
                     $found,
                     $client->id,
                     $category,
-                    $this->clientStatusFor($clientSeq),
+                    $this->getClientStatus($clientSeq),
                     $adminId,
                     $clientSeq,
                     $this->getClientDescriptions()[$category],
@@ -128,7 +128,7 @@ class SupportTicketSeeder extends Seeder
             ->first();
     }
 
-    private function artistStatusFor(int $seq): string
+    private function getArtistStatus(int $seq): string
     {
         $statuses = [
             SupportTicket::STATUS_OPEN,
@@ -139,7 +139,7 @@ class SupportTicketSeeder extends Seeder
         return $statuses[$seq % count($statuses)];
     }
 
-    private function clientStatusFor(int $seq): string
+    private function getClientStatus(int $seq): string
     {
         $statuses = [
             SupportTicket::STATUS_UNDER_REVIEW,

--- a/database/seeders/SupportTicketSeeder.php
+++ b/database/seeders/SupportTicketSeeder.php
@@ -26,9 +26,9 @@ class SupportTicketSeeder extends Seeder
             $query->where('slug', User::ROLE_CLIENT);
         })->orderBy('id')->get(['id']);
 
-        $usedSaleIds  = [];
-        $artistSeq    = 0;
-        $clientSeq    = 0;
+        $usedSaleIds = [];
+        $artistSeq = 0;
+        $clientSeq = 0;
 
         $artistLimit = max(1, intdiv($artists->count(), 2));
         $clientLimit = max(1, intdiv($clients->count(), 2));
@@ -49,7 +49,7 @@ class SupportTicketSeeder extends Seeder
                     $this->artistStatusFor($artistSeq),
                     $adminId,
                     $artistSeq,
-                    $this->artistDescriptions()[$category],
+                    $this->getArtistDescriptions()[$category],
                     'artist',
                     $artistSeq
                 );
@@ -70,7 +70,7 @@ class SupportTicketSeeder extends Seeder
                     $this->clientStatusFor($clientSeq),
                     $adminId,
                     $clientSeq,
-                    $this->clientDescriptions()[$category],
+                    $this->getClientDescriptions()[$category],
                     'client',
                     $clientSeq
                 );
@@ -107,7 +107,7 @@ class SupportTicketSeeder extends Seeder
                     SupportTicket::STATUS_OPEN,
                     $adminId,
                     $seq,
-                    $this->clientDescriptions()[$category],
+                    $this->getClientDescriptions()[$category],
                     'client',
                     $seq
                 );
@@ -150,24 +150,24 @@ class SupportTicketSeeder extends Seeder
         return $statuses[$seq % count($statuses)];
     }
 
-    private function artistDescriptions(): array
+    private function getArtistDescriptions(): array
     {
         return [
-            SupportTicket::CATEGORY_NO_SHOW    => 'El cliente no estuvo presente en el lugar y hora acordados del evento.',
+            SupportTicket::CATEGORY_NO_SHOW => 'El cliente no estuvo presente en el lugar y hora acordados del evento.',
             SupportTicket::CATEGORY_BAD_SERVICE => 'El cliente tuvo un comportamiento agresivo e irrespetuoso con el artista y su equipo.',
             SupportTicket::CATEGORY_CANCELLATION => 'El cliente canceló el evento de último minuto sin aviso previo suficiente.',
-            SupportTicket::CATEGORY_OTHER       => 'Situación adicional con el cliente que requiere revisión de soporte.',
+            SupportTicket::CATEGORY_OTHER => 'Situación adicional con el cliente que requiere revisión de soporte.',
         ];
     }
 
-    private function clientDescriptions(): array
+    private function getClientDescriptions(): array
     {
         return [
-            SupportTicket::CATEGORY_NO_SHOW    => 'El artista nunca se presentó al evento contratado y no respondió a los mensajes previos.',
-            SupportTicket::CATEGORY_DELAY      => 'El artista llegó con más de una hora de retraso al evento.',
+            SupportTicket::CATEGORY_NO_SHOW => 'El artista nunca se presentó al evento contratado y no respondió a los mensajes previos.',
+            SupportTicket::CATEGORY_DELAY => 'El artista llegó con más de una hora de retraso al evento.',
             SupportTicket::CATEGORY_BAD_SERVICE => 'El comportamiento del artista durante el evento fue inadecuado e irrespetuoso.',
             SupportTicket::CATEGORY_CANCELLATION => 'El artista canceló el evento de último minuto sin aviso previo suficiente.',
-            SupportTicket::CATEGORY_OTHER       => 'Situación adicional con el artista que requiere revisión de soporte.',
+            SupportTicket::CATEGORY_OTHER => 'Situación adicional con el artista que requiere revisión de soporte.',
         ];
     }
 
@@ -185,21 +185,21 @@ class SupportTicketSeeder extends Seeder
         $resolutionType = match ($status) {
             SupportTicket::STATUS_RESOLVED => SupportTicket::RESOLUTION_TYPES[$seqForDate % count(SupportTicket::RESOLUTION_TYPES)],
             SupportTicket::STATUS_REJECTED => 'no_action',
-            default                        => null,
+            default => null,
         };
 
-        $openedAt   = $direction === 'artist'
+        $openedAt = $direction === 'artist'
             ? Carbon::now()->subDays(20 - ($seqForDate % 14))->setTime(10, 0)->addMinutes($seqForDate * 13)
             : Carbon::now()->subDays(18 - ($seqForDate % 12))->setTime(14, 30)->addMinutes($seqForDate * 17);
         $reviewerId = $adminId ?: $reporterUserId;
 
         $ticket = new SupportTicket([
-            'artist_sale_id'   => $sale->id,
+            'artist_sale_id' => $sale->id,
             'reporter_user_id' => $reporterUserId,
-            'category'         => $category,
-            'description'      => $description,
-            'status'           => $status,
-            'resolution_type'  => $resolutionType,
+            'category' => $category,
+            'description' => $description,
+            'status' => $status,
+            'resolution_type' => $resolutionType,
         ]);
         $ticket->created_at = $openedAt;
         $ticket->save();
@@ -226,12 +226,12 @@ class SupportTicketSeeder extends Seeder
     private function creationLog(int $ticketId, int $userId, Carbon $at): array
     {
         return [
-            'support_ticket_id'  => $ticketId,
+            'support_ticket_id' => $ticketId,
             'changed_by_user_id' => $userId,
-            'status'             => SupportTicket::STATUS_OPEN,
-            'resolution_type'    => null,
-            'notes'              => 'Ticket creado.',
-            'created_at'         => $at->copy(),
+            'status' => SupportTicket::STATUS_OPEN,
+            'resolution_type' => null,
+            'notes' => 'Ticket creado.',
+            'created_at' => $at->copy(),
         ];
     }
 
@@ -242,12 +242,12 @@ class SupportTicketSeeder extends Seeder
             SupportTicket::STATUS_RESOLVED,
             SupportTicket::STATUS_REJECTED,
         ], true) ? [
-            'support_ticket_id'  => $ticketId,
+            'support_ticket_id' => $ticketId,
             'changed_by_user_id' => $userId,
-            'status'             => SupportTicket::STATUS_UNDER_REVIEW,
-            'resolution_type'    => null,
-            'notes'              => 'El equipo de soporte tomó el caso y comenzó la revisión.',
-            'created_at'         => $at->copy()->addDay(),
+            'status' => SupportTicket::STATUS_UNDER_REVIEW,
+            'resolution_type' => null,
+            'notes' => 'El equipo de soporte tomó el caso y comenzó la revisión.',
+            'created_at' => $at->copy()->addDay(),
         ] : null;
     }
 
@@ -260,14 +260,14 @@ class SupportTicketSeeder extends Seeder
         ];
 
         return in_array($status, [SupportTicket::STATUS_RESOLVED, SupportTicket::STATUS_REJECTED], true) ? [
-            'support_ticket_id'  => $ticketId,
+            'support_ticket_id' => $ticketId,
             'changed_by_user_id' => $userId,
-            'status'             => $status,
-            'resolution_type'    => $resolutionType,
-            'notes'              => $status === SupportTicket::STATUS_RESOLVED
+            'status' => $status,
+            'resolution_type' => $resolutionType,
+            'notes' => $status === SupportTicket::STATUS_RESOLVED
                 ? $resolutionNotes[$resolutionType]
                 : 'El reporte fue rechazado tras revisar las evidencias.',
-            'created_at'         => $at->copy()->addDays(2),
+            'created_at' => $at->copy()->addDays(2),
         ] : null;
     }
 }

--- a/database/seeders/SupportTicketSeeder.php
+++ b/database/seeders/SupportTicketSeeder.php
@@ -17,113 +17,257 @@ class SupportTicketSeeder extends Seeder
     {
         DB::statement('TRUNCATE TABLE ticket_logs, support_tickets RESTART IDENTITY CASCADE;');
 
-        $clientCategories = ['no_show', 'delay', 'bad_service', 'cancellation', 'other'];
-        $artistCategories = ['cancellation', 'other'];
-        $statuses = [
-            SupportTicket::STATUS_OPEN,
-            SupportTicket::STATUS_UNDER_REVIEW,
-            SupportTicket::STATUS_RESOLVED,
-            SupportTicket::STATUS_REJECTED,
-        ];
-        $resolutionTypes = ['full_refund', 'partial_refund', 'no_action'];
+        $adminId = User::whereHas('roles', function ($query) {
+            $query->where('slug', User::ROLE_ADMIN);
+        })->orderBy('id')->value('id');
 
-        $artists = Artist::query()->orderBy('id')->get(['id', 'user_id', 'name']);
+        $artists = Artist::query()->orderBy('id')->get(['id', 'user_id']);
         $clients = User::whereHas('roles', function ($query) {
             $query->where('slug', User::ROLE_CLIENT);
-        })->orderBy('id')->get(['id', 'name']);
+        })->orderBy('id')->get(['id']);
+
+        $usedSaleIds  = [];
+        $artistSeq    = 0;
+        $clientSeq    = 0;
 
         $artistLimit = max(1, intdiv($artists->count(), 2));
         $clientLimit = max(1, intdiv($clients->count(), 2));
 
-        $this->createArtistTickets($artists->take($artistLimit), $artistCategories, $statuses, $resolutionTypes);
-        $this->createClientTickets($clients->take($clientLimit), $clientCategories, $statuses, $resolutionTypes);
+        $artistCategories = SupportTicket::CATEGORIES_ARTIST;
+        $clientCategories = SupportTicket::CATEGORIES_CUSTOMER;
+
+        foreach ($artists->take($artistLimit)->values() as $artist) {
+            $sale = $this->findPastSale('artist_id', $artist->id, $usedSaleIds);
+            $usedSaleIds[] = $sale?->id ?? -1;
+
+            optional($sale, function (ArtistSale $found) use ($artist, $adminId, $artistSeq, $artistCategories) {
+                $category = $artistCategories[$artistSeq % count($artistCategories)];
+                $this->createTicketWithHistory(
+                    $found,
+                    $artist->user_id,
+                    $category,
+                    $this->artistStatusFor($artistSeq),
+                    $adminId,
+                    $artistSeq,
+                    $this->artistDescriptions()[$category],
+                    'artist',
+                    $artistSeq
+                );
+            });
+            $artistSeq++;
+        }
+
+        foreach ($clients->take($clientLimit)->values() as $client) {
+            $sale = $this->findPastSale('customer_id', $client->id, $usedSaleIds);
+            $usedSaleIds[] = $sale?->id ?? -1;
+
+            optional($sale, function (ArtistSale $found) use ($client, $adminId, $clientSeq, $clientCategories) {
+                $category = $clientCategories[$clientSeq % count($clientCategories)];
+                $this->createTicketWithHistory(
+                    $found,
+                    $client->id,
+                    $category,
+                    $this->clientStatusFor($clientSeq),
+                    $adminId,
+                    $clientSeq,
+                    $this->clientDescriptions()[$category],
+                    'client',
+                    $clientSeq
+                );
+            });
+            $clientSeq++;
+        }
+
+        $this->ensureAgainstTickets($artists->take($artistLimit), $adminId, $usedSaleIds);
     }
 
-    private function createArtistTickets($artists, array $categories, array $statuses, array $resolutionTypes)
+    private function ensureAgainstTickets($artists, ?int $adminId, array &$usedSaleIds): void
     {
-        foreach ($artists->values() as $index => $artist) {
+        $againstCategories = SupportTicket::CATEGORIES_CUSTOMER;
+
+        $artistsNeedingTickets = collect($artists->values())->filter(
+            fn (Artist $artist) => ! SupportTicket::whereHas('artistSale.artist', fn ($q) => $q->where('user_id', $artist->user_id))
+                ->where('reporter_user_id', '!=', $artist->user_id)
+                ->exists()
+        )->values();
+
+        $artistsNeedingTickets->reduce(function (int $seq, Artist $artist) use ($adminId, $usedSaleIds, $againstCategories) {
             $sale = ArtistSale::query()
                 ->where('artist_id', $artist->id)
                 ->whereDate('event_date', '<=', Carbon::today())
-                ->orderBy('event_date')
-                ->orderBy('id')
+                ->orderByDesc('event_date')
                 ->first();
 
-            if (!$sale) {
-                $sale = ArtistSale::query()
-                    ->where('artist_id', $artist->id)
-                    ->orderBy('event_date')
-                    ->orderBy('id')
-                    ->first();
-            }
+            optional($sale, function (ArtistSale $found) use ($artist, $adminId, $seq, $againstCategories) {
+                $category = $againstCategories[$seq % count($againstCategories)];
+                $this->createTicketWithHistory(
+                    $found,
+                    $found->customer_id,
+                    $category,
+                    SupportTicket::STATUS_OPEN,
+                    $adminId,
+                    $seq,
+                    $this->clientDescriptions()[$category],
+                    'client',
+                    $seq
+                );
+            });
 
-            if (!$sale) {
-                continue;
-            }
-
-            $this->createTicket(
-                $sale,
-                $artist->user_id,
-                $categories[$index % count($categories)],
-                $statuses[$index % count($statuses)],
-                $resolutionTypes[$index % count($resolutionTypes)]
-            );
-        }
+            return $seq + 1;
+        }, 0);
     }
 
-    private function createClientTickets($clients, array $categories, array $statuses, array $resolutionTypes)
+    private function findPastSale(string $column, int $value, array $excludedSaleIds): ?ArtistSale
     {
-        foreach ($clients->values() as $index => $client) {
-            $sale = ArtistSale::query()
-                ->where('customer_id', $client->id)
-                ->whereDate('event_date', '<=', Carbon::today())
-                ->orderBy('event_date')
-                ->orderBy('id')
-                ->first();
-
-            if (!$sale) {
-                $sale = ArtistSale::query()
-                    ->where('customer_id', $client->id)
-                    ->orderBy('event_date')
-                    ->orderBy('id')
-                    ->first();
-            }
-
-            if (!$sale) {
-                continue;
-            }
-
-            $this->createTicket(
-                $sale,
-                $client->id,
-                $categories[$index % count($categories)],
-                $statuses[$index % count($statuses)],
-                $resolutionTypes[$index % count($resolutionTypes)]
-            );
-        }
+        return ArtistSale::query()
+            ->where($column, $value)
+            ->whereDate('event_date', '<=', Carbon::today())
+            ->when(!empty($excludedSaleIds), fn ($q) => $q->whereNotIn('id', $excludedSaleIds))
+            ->orderByDesc('event_date')
+            ->orderBy('id')
+            ->first();
     }
 
-    private function createTicket(ArtistSale $sale, int $reporterUserId, string $category, string $status, string $resolutionType)
+    private function artistStatusFor(int $seq): string
     {
-        if (in_array($status, [SupportTicket::STATUS_OPEN, SupportTicket::STATUS_UNDER_REVIEW], true)) {
-            $resolutionType = null;
-        }
+        $statuses = [
+            SupportTicket::STATUS_OPEN,
+            SupportTicket::STATUS_RESOLVED,
+            SupportTicket::STATUS_UNDER_REVIEW,
+            SupportTicket::STATUS_REJECTED,
+        ];
+        return $statuses[$seq % count($statuses)];
+    }
 
-        $ticket = SupportTicket::create([
+    private function clientStatusFor(int $seq): string
+    {
+        $statuses = [
+            SupportTicket::STATUS_UNDER_REVIEW,
+            SupportTicket::STATUS_OPEN,
+            SupportTicket::STATUS_REJECTED,
+            SupportTicket::STATUS_RESOLVED,
+        ];
+        return $statuses[$seq % count($statuses)];
+    }
+
+    private function artistDescriptions(): array
+    {
+        return [
+            SupportTicket::CATEGORY_NO_SHOW    => 'El cliente no estuvo presente en el lugar y hora acordados del evento.',
+            SupportTicket::CATEGORY_BAD_SERVICE => 'El cliente tuvo un comportamiento agresivo e irrespetuoso con el artista y su equipo.',
+            SupportTicket::CATEGORY_CANCELLATION => 'El cliente canceló el evento de último minuto sin aviso previo suficiente.',
+            SupportTicket::CATEGORY_OTHER       => 'Situación adicional con el cliente que requiere revisión de soporte.',
+        ];
+    }
+
+    private function clientDescriptions(): array
+    {
+        return [
+            SupportTicket::CATEGORY_NO_SHOW    => 'El artista nunca se presentó al evento contratado y no respondió a los mensajes previos.',
+            SupportTicket::CATEGORY_DELAY      => 'El artista llegó con más de una hora de retraso al evento.',
+            SupportTicket::CATEGORY_BAD_SERVICE => 'El comportamiento del artista durante el evento fue inadecuado e irrespetuoso.',
+            SupportTicket::CATEGORY_CANCELLATION => 'El artista canceló el evento de último minuto sin aviso previo suficiente.',
+            SupportTicket::CATEGORY_OTHER       => 'Situación adicional con el artista que requiere revisión de soporte.',
+        ];
+    }
+
+    private function createTicketWithHistory(
+        ArtistSale $sale,
+        int $reporterUserId,
+        string $category,
+        string $status,
+        ?int $adminId,
+        int $seq,
+        string $description,
+        string $direction,
+        int $seqForDate
+    ): void {
+        $resolutionType = match ($status) {
+            SupportTicket::STATUS_RESOLVED => SupportTicket::RESOLUTION_TYPES[$seqForDate % count(SupportTicket::RESOLUTION_TYPES)],
+            SupportTicket::STATUS_REJECTED => 'no_action',
+            default                        => null,
+        };
+
+        $openedAt   = $direction === 'artist'
+            ? Carbon::now()->subDays(20 - ($seqForDate % 14))->setTime(10, 0)->addMinutes($seqForDate * 13)
+            : Carbon::now()->subDays(18 - ($seqForDate % 12))->setTime(14, 30)->addMinutes($seqForDate * 17);
+        $reviewerId = $adminId ?: $reporterUserId;
+
+        $ticket = new SupportTicket([
             'artist_sale_id'   => $sale->id,
             'reporter_user_id' => $reporterUserId,
             'category'         => $category,
-            'description'      => 'Ticket de soporte generado por seeder para la venta #' . $sale->id . '.',
+            'description'      => $description,
             'status'           => $status,
             'resolution_type'  => $resolutionType,
         ]);
+        $ticket->created_at = $openedAt;
+        $ticket->save();
 
-        TicketLog::create([
-            'support_ticket_id'  => $ticket->id,
-            'changed_by_user_id' => $reporterUserId,
+        $logs = array_values(array_filter([
+            $this->creationLog($ticket->id, $reporterUserId, $openedAt),
+            $this->reviewLog($ticket->id, $reviewerId, $openedAt, $status),
+            $this->closureLog($ticket->id, $reviewerId, $openedAt, $status, $resolutionType),
+        ]));
+
+        collect($logs)->each(function (array $data) {
+            $createdAt = $data['created_at'];
+            unset($data['created_at']);
+
+            $log = new TicketLog($data);
+            $log->created_at = $createdAt;
+            $log->save();
+        });
+
+        $ticket->updated_at = $logs[count($logs) - 1]['created_at'];
+        $ticket->save();
+    }
+
+    private function creationLog(int $ticketId, int $userId, Carbon $at): array
+    {
+        return [
+            'support_ticket_id'  => $ticketId,
+            'changed_by_user_id' => $userId,
+            'status'             => SupportTicket::STATUS_OPEN,
+            'resolution_type'    => null,
+            'notes'              => 'Ticket creado.',
+            'created_at'         => $at->copy(),
+        ];
+    }
+
+    private function reviewLog(int $ticketId, int $userId, Carbon $at, string $status): ?array
+    {
+        return in_array($status, [
+            SupportTicket::STATUS_UNDER_REVIEW,
+            SupportTicket::STATUS_RESOLVED,
+            SupportTicket::STATUS_REJECTED,
+        ], true) ? [
+            'support_ticket_id'  => $ticketId,
+            'changed_by_user_id' => $userId,
+            'status'             => SupportTicket::STATUS_UNDER_REVIEW,
+            'resolution_type'    => null,
+            'notes'              => 'El equipo de soporte tomó el caso y comenzó la revisión.',
+            'created_at'         => $at->copy()->addDay(),
+        ] : null;
+    }
+
+    private function closureLog(int $ticketId, int $userId, Carbon $at, string $status, ?string $resolutionType): ?array
+    {
+        $resolutionNotes = [
+            'full_refund'    => 'Se aplicó reembolso total al cliente.',
+            'partial_refund' => 'Se aplicó reembolso parcial al cliente.',
+            'no_action'      => 'Ticket resuelto sin acción adicional sobre la orden.',
+        ];
+
+        return in_array($status, [SupportTicket::STATUS_RESOLVED, SupportTicket::STATUS_REJECTED], true) ? [
+            'support_ticket_id'  => $ticketId,
+            'changed_by_user_id' => $userId,
             'status'             => $status,
             'resolution_type'    => $resolutionType,
-            'notes'              => 'Ticket creado por seeder.',
-        ]);
+            'notes'              => $status === SupportTicket::STATUS_RESOLVED
+                ? $resolutionNotes[$resolutionType]
+                : 'El reporte fue rechazado tras revisar las evidencias.',
+            'created_at'         => $at->copy()->addDays(2),
+        ] : null;
     }
 }

--- a/database/seeders/UserSanctionSeeder.php
+++ b/database/seeders/UserSanctionSeeder.php
@@ -81,7 +81,7 @@ class UserSanctionSeeder extends Seeder
                 $query->where('user_id', $user->id);
             })->orderBy('event_date'),
             'cliente' => ArtistSale::where('customer_id', $user->id)->orderBy('event_date'),
-            default   => null,
+            default => null,
         };
 
         optional($saleQuery?->first(), function (ArtistSale $sale) use ($user, $reason) {
@@ -123,28 +123,28 @@ class UserSanctionSeeder extends Seeder
 
         $ticketLogs = [
             [
-                'support_ticket_id'  => $ticket->id,
+                'support_ticket_id' => $ticket->id,
                 'changed_by_user_id' => $adminUser->id,
-                'status'             => SupportTicket::STATUS_OPEN,
-                'resolution_type'    => null,
-                'notes'              => 'Ticket creado.',
-                'created_at'         => $openedAt->copy(),
+                'status' => SupportTicket::STATUS_OPEN,
+                'resolution_type' => null,
+                'notes' => 'Ticket creado.',
+                'created_at' => $openedAt->copy(),
             ],
             [
-                'support_ticket_id'  => $ticket->id,
+                'support_ticket_id' => $ticket->id,
                 'changed_by_user_id' => $adminUser->id,
-                'status'             => SupportTicket::STATUS_UNDER_REVIEW,
-                'resolution_type'    => null,
-                'notes'              => 'El equipo de soporte tomó el caso y comenzó la revisión.',
-                'created_at'         => $openedAt->copy()->addDay(),
+                'status' => SupportTicket::STATUS_UNDER_REVIEW,
+                'resolution_type' => null,
+                'notes' => 'El equipo de soporte tomó el caso y comenzó la revisión.',
+                'created_at' => $openedAt->copy()->addDay(),
             ],
             [
-                'support_ticket_id'  => $ticket->id,
+                'support_ticket_id' => $ticket->id,
                 'changed_by_user_id' => $adminUser->id,
-                'status'             => SupportTicket::STATUS_RESOLVED,
-                'resolution_type'    => 'partial_refund',
-                'notes'              => 'Se aplicó reembolso parcial al cliente y sanción al responsable.',
-                'created_at'         => $openedAt->copy()->addDays(2),
+                'status' => SupportTicket::STATUS_RESOLVED,
+                'resolution_type' => 'partial_refund',
+                'notes' => 'Se aplicó reembolso parcial al cliente y sanción al responsable.',
+                'created_at' => $openedAt->copy()->addDays(2),
             ],
         ];
 

--- a/database/seeders/UserSanctionSeeder.php
+++ b/database/seeders/UserSanctionSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\ArtistSale;
 use App\Models\EventCancellation;
 use App\Models\SupportTicket;
+use App\Models\TicketLog;
 use App\Models\User;
 use App\Models\UserSanction;
 use Carbon\Carbon;
@@ -14,7 +15,7 @@ class UserSanctionSeeder extends Seeder
 {
     public function run()
     {
-        $sale = ArtistSale::first();
+        $sale = ArtistSale::whereDoesntHave('supportTickets')->first();
         $adminUser = User::first();
 
         $artistAccount = User::where('email', 'miguel@gmail.com')->first();
@@ -51,21 +52,10 @@ class UserSanctionSeeder extends Seeder
         foreach ($targets as $role => $user) {
             $pattern = $sanctionByRole[$role];
             $user->update(['account_status' => $pattern['type']]);
-            $sanctionableType = null;
-            $sanctionableId = null;
-
-            if ($pattern['source'] === 'ticket') {
-                $ticket = SupportTicket::create([
-                    'artist_sale_id' => $sale->id,
-                    'reporter_user_id' => $adminUser->id,
-                    'category' => 'bad_service',
-                    'description' => 'Reporte autogenerado para justificar sanción: ' . $pattern['reason'],
-                    'status' => SupportTicket::STATUS_RESOLVED,
-                    'resolution_type' => 'partial_refund',
-                ]);
-                $sanctionableType = SupportTicket::class;
-                $sanctionableId = $ticket->id;
-            }
+            [$sanctionableType, $sanctionableId] = match ($pattern['source']) {
+                'ticket' => $this->createSanctionTicket($sale, $adminUser, $pattern),
+                default  => [null, null],
+            };
             $endsAt = $pattern['days'] ? Carbon::now()->addDays($pattern['days']) : null;
             $creator = (string) $adminUser->id;
 
@@ -91,32 +81,85 @@ class UserSanctionSeeder extends Seeder
                 $query->where('user_id', $user->id);
             })->orderBy('event_date'),
             'cliente' => ArtistSale::where('customer_id', $user->id)->orderBy('event_date'),
-            default => null,
+            default   => null,
         };
 
-        $sale = $saleQuery?->first();
+        optional($saleQuery?->first(), function (ArtistSale $sale) use ($user, $reason) {
+            $penaltyPercentage = 30;
+            $sale->event_date = Carbon::now()->addDays(4)->toDateString();
+            $sale->event_status = ArtistSale::EVENT_STATUS_CANCELLED;
+            $sale->approval_status = ArtistSale::APPROVAL_STATUS_CANCELLED;
+            $sale->approval_responded_at = Carbon::now();
+            $sale->save();
 
-        if (!$sale) {
-            return;
-        }
+            $cancellation = new EventCancellation([
+                'artist_sale_id' => $sale->id,
+                'user_id' => $user->id,
+                'cancellation_reason' => 'Cancelación registrada para historial: ' . $reason,
+                'penalty_percentage' => $penaltyPercentage,
+                'penalty_amount' => round(floatval($sale->amount) * ($penaltyPercentage / 100), 2),
+                'refunded_at' => null,
+                'penalty_paid' => true,
+            ]);
+            $cancellation->created_at = Carbon::now()->addMinute();
+            $cancellation->save();
+        });
+    }
 
-        $penaltyPercentage = 30;
-        $sale->event_date = Carbon::now()->addDays(4)->toDateString();
-        $sale->event_status = ArtistSale::EVENT_STATUS_CANCELLED;
-        $sale->approval_status = ArtistSale::APPROVAL_STATUS_CANCELLED;
-        $sale->approval_responded_at = Carbon::now();
-        $sale->save();
+    private function createSanctionTicket(ArtistSale $sale, User $adminUser, array $pattern): array
+    {
+        $openedAt = Carbon::now()->subDays(3)->setTime(11, 0);
 
-        $cancellation = new EventCancellation([
+        $ticket = new SupportTicket([
             'artist_sale_id' => $sale->id,
-            'user_id' => $user->id,
-            'cancellation_reason' => 'Cancelación registrada para historial: ' . $reason,
-            'penalty_percentage' => $penaltyPercentage,
-            'penalty_amount' => round(floatval($sale->amount) * ($penaltyPercentage / 100), 2),
-            'refunded_at' => null,
-            'penalty_paid' => true,
+            'reporter_user_id' => $adminUser->id,
+            'category' => SupportTicket::CATEGORY_BAD_SERVICE,
+            'description' => 'Reporte autogenerado para justificar sanción: ' . $pattern['reason'],
+            'status' => SupportTicket::STATUS_RESOLVED,
+            'resolution_type' => 'partial_refund',
         ]);
-        $cancellation->created_at = Carbon::now()->addMinute();
-        $cancellation->save();
+        $ticket->created_at = $openedAt;
+        $ticket->save();
+
+        $ticketLogs = [
+            [
+                'support_ticket_id'  => $ticket->id,
+                'changed_by_user_id' => $adminUser->id,
+                'status'             => SupportTicket::STATUS_OPEN,
+                'resolution_type'    => null,
+                'notes'              => 'Ticket creado.',
+                'created_at'         => $openedAt->copy(),
+            ],
+            [
+                'support_ticket_id'  => $ticket->id,
+                'changed_by_user_id' => $adminUser->id,
+                'status'             => SupportTicket::STATUS_UNDER_REVIEW,
+                'resolution_type'    => null,
+                'notes'              => 'El equipo de soporte tomó el caso y comenzó la revisión.',
+                'created_at'         => $openedAt->copy()->addDay(),
+            ],
+            [
+                'support_ticket_id'  => $ticket->id,
+                'changed_by_user_id' => $adminUser->id,
+                'status'             => SupportTicket::STATUS_RESOLVED,
+                'resolution_type'    => 'partial_refund',
+                'notes'              => 'Se aplicó reembolso parcial al cliente y sanción al responsable.',
+                'created_at'         => $openedAt->copy()->addDays(2),
+            ],
+        ];
+
+        collect($ticketLogs)->each(function (array $data) {
+            $createdAt = $data['created_at'];
+            unset($data['created_at']);
+
+            $log = new TicketLog($data);
+            $log->created_at = $createdAt;
+            $log->save();
+        });
+
+        $ticket->updated_at = $openedAt->copy()->addDays(2);
+        $ticket->save();
+
+        return [SupportTicket::class, $ticket->id];
     }
 }


### PR DESCRIPTION
Fixes support tickets: expands artist allowed categories with constants, fixes category labels with reporter role context, rewrites seeders without if/else, adds ensureAgainstTickets for en-contra coverage, validates index filters and resolution_type on resolve/reject, removes duplicate route, adds role accessor on User model.